### PR TITLE
Fix stale dedup by marking seen IDs only after successful flush

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ content-bridge.js (ISOLATED world)
   ▼
 background.js (Service Worker, ES module)
   │  Parses tweet data via lib/tweet-parser.js
-  │  Deduplicates (Set of seen IDs, max 50k; session storage in dev, local in prod)
+  │  Deduplicates (pending IDs in-memory, seen IDs persisted; max 50k seen IDs)
   │  Batches (50 tweets or 30–45s jittered flush)
   │  Debug logging: intercepts console.log/warn/error, sends to host
   │  Transport abstraction: tries HTTP daemon first, falls back to native messaging
@@ -52,7 +52,7 @@ debug-YYYY-MM-DD.log     (when debug logging enabled)
 - **Shared core logic:** `xtap_core.py` contains all file I/O logic (load seen IDs, resolve output dir, write tweets/logs, test path), used by both `xtap_host.py` and `xtap_daemon.py`.
 - **Environment detection:** `isDevMode = !chrome.runtime.getManifest().update_url` — packed CWS extensions have `update_url`, unpacked don't. Used to switch seenIds storage between session (dev) and local (production).
 - **Volatile dev cache:** In dev mode (unpacked), `seenIds` is stored in `chrome.storage.session`, which clears on extension reload. This eliminates the need to manually clear storage during development. Production behavior is unchanged (persisted to `chrome.storage.local`).
-- **Dedup in service worker:** Multiple tabs feed the same service worker. `seenIds` Set (max 50,000, FIFO eviction) prevents duplicates. In production, persisted to `chrome.storage.local` across sessions; in dev mode, uses volatile `chrome.storage.session`. Both host and daemon also load seen IDs from existing JSONL files on startup.
+- **Dedup in service worker:** Multiple tabs feed the same service worker. New IDs first enter an in-memory `pendingIds` set, then move to persisted `seenIds` only after a successful flush send. This avoids stale dedup entries if the worker restarts before flush. `seenIds` is capped at 50,000 with FIFO eviction; in production it persists in `chrome.storage.local`, and in dev mode it uses volatile `chrome.storage.session`. Both host and daemon also load seen IDs from existing JSONL files on startup.
 - **Jittered flush:** Batch flush uses `setTimeout` with randomized interval (30s base + up to 50% jitter = 30–45s), re-randomized each cycle. Avoids clockwork-regular patterns.
 - **Path validation:** When the user sets a custom output directory, the service worker sends a `TEST_PATH` message (via HTTP or native), which attempts `makedirs` + write/delete of a temp file before accepting the path.
 - **Error resilience:** The native host wraps per-message handling in try/except and responds with `{ok: false, error: "..."}` instead of crashing. The HTTP daemon returns error status codes. The service worker tracks rapid disconnects to detect crash loops and auto-falls back from HTTP to native on failure.

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ xTap is a Chrome extension that silently intercepts the GraphQL API responses X/
 
 1. A MAIN world content script patches `fetch` and `XMLHttpRequest.open()` to observe GraphQL responses as they arrive
 2. Payloads are relayed via a random-named `CustomEvent` to an ISOLATED world bridge, which forwards them to the service worker
-3. The service worker parses, normalizes, deduplicates, and batches tweets
+3. The service worker parses, normalizes, deduplicates, and batches tweets (`pendingIds` while buffered, then `seenIds` after successful flush send)
 4. Batches are sent to disk via one of two transports:
    - **HTTP daemon**: a standalone `xtap_daemon.py` process on `127.0.0.1:17381`, managed by launchd (macOS), systemd (Linux), or Scheduled Task (Windows). On macOS, it runs outside Chrome's TCC sandbox and can write to protected paths like `~/Documents` and iCloud Drive
    - **Native messaging**: `xtap_host.py` over Chrome's stdio protocol — used at startup to retrieve the daemon's auth token (`GET_TOKEN`), and as a data transport fallback if HTTP is unavailable
@@ -288,7 +288,7 @@ After modifying extension files (`background.js`, `lib/`, `content-*.js`, `popup
 
 **Debug dashboard:** Click "Debug Dashboard" in the popup to open a live view of capture events, transport health, and a parser sandbox for testing `extractTweets` against raw GraphQL JSON. Debug logging and discovery mode toggles are also here — enable debug logging to write timestamped service worker logs to `debug-YYYY-MM-DD.log`, or discovery mode to log endpoint response shapes to the console.
 
-**Dev mode:** When loaded unpacked (developer mode), the extension uses `chrome.storage.session` for the `seenIds` dedup cache instead of `chrome.storage.local`. This means reloading the extension automatically clears the cache — no need to manually clear storage between test runs. Production (CWS) behavior is unchanged.
+**Dev mode:** When loaded unpacked (developer mode), the extension uses `chrome.storage.session` for the `seenIds` dedup cache instead of `chrome.storage.local`. This means reloading the extension automatically clears the cache — no need to manually clear storage between test runs. Production (CWS) behavior is unchanged. (Note: `pendingIds` is in-memory only and never persisted.)
 
 After modifying Python host files (`xtap_core.py`, `xtap_host.py`, `xtap_daemon.py`), the native host picks up changes on next Chrome restart. To restart the HTTP daemon immediately:
 

--- a/background.js
+++ b/background.js
@@ -12,6 +12,7 @@ let nativePort = null;
 let buffer = [];
 let flushTimer = null;
 let seenIds = new Set();
+let pendingIds = new Set();
 let sessionCount = 0;
 let allTimeCount = 0;
 let outputDir = '';
@@ -63,6 +64,13 @@ async function restoreState() {
   if (typeof stored.outputDir === 'string') outputDir = stored.outputDir;
   if (typeof stored.debugLogging === 'boolean') debugLogging = stored.debugLogging;
   if (typeof stored.verboseLogging === 'boolean') verboseLogging = stored.verboseLogging;
+}
+
+function trimSeenIds() {
+  if (seenIds.size > MAX_SEEN_IDS) {
+    const arr = [...seenIds];
+    seenIds = new Set(arr.slice(arr.length - MAX_SEEN_IDS));
+  }
 }
 
 // --- Debug logging ---
@@ -318,10 +326,25 @@ async function flush() {
     if (outputDir) message.outputDir = outputDir;
 
     try {
+      const transportBefore = transport;
       const resp = await sendToHost(message);
-      if (resp && !resp.ok) {
-        console.error('[xTap] Host rejected tweets:', resp.error);
+      const sentViaHttp = transportBefore === 'http' && transport === 'http';
+      const sentViaNative = transport === 'native' && nativePort;
+      if (sentViaHttp) {
+        if (!resp || !resp.ok) {
+          throw new Error(resp?.error || 'HTTP host rejected tweets');
+        }
+      } else if (!sentViaNative) {
+        throw new Error('No transport available');
       }
+
+      for (const tweet of batch) {
+        if (!tweet.id) continue;
+        pendingIds.delete(tweet.id);
+        seenIds.add(tweet.id);
+      }
+      trimSeenIds();
+      saveState();
     } catch (e) {
       console.error('[xTap] Send failed, buffering tweets back:', e);
       buffer.unshift(...batch);
@@ -364,25 +387,20 @@ function enqueueTweets(tweets, endpoint = 'unknown') {
     }
 
     // Article tweets bypass dedup — they enrich a previously captured stub
-    if (seenIds.has(tweet.id) && !tweet.is_article) {
-      emitTraceEvent({ timestamp: Date.now(), endpoint, tweetId: tweet.id, status: 'DEDUPLICATED', reason: 'seenIds' });
+    const dedupSource = seenIds.has(tweet.id) ? 'seenIds' : (pendingIds.has(tweet.id) ? 'pendingIds' : null);
+    if (dedupSource && !tweet.is_article) {
+      emitTraceEvent({ timestamp: Date.now(), endpoint, tweetId: tweet.id, status: 'DEDUPLICATED', reason: dedupSource });
       continue;
     }
-    seenIds.add(tweet.id);
+    if (tweet.id) pendingIds.add(tweet.id);
     buffer.push(tweet);
     newCount++;
     emitTraceEvent({ timestamp: Date.now(), endpoint, tweetId: tweet.id, status: 'ACCEPTED', reason: null });
   }
 
-  // FIFO eviction if seenIds grows too large
-  if (seenIds.size > MAX_SEEN_IDS) {
-    const arr = [...seenIds];
-    seenIds = new Set(arr.slice(arr.length - MAX_SEEN_IDS));
-  }
-
   const dupeCount = tweets.length - newCount;
   if (dupeCount > 0) {
-    console.log(`[xTap] Dedup: ${newCount} new, ${dupeCount} duplicates skipped (seenIds: ${seenIds.size})`);
+    console.log(`[xTap] Dedup: ${newCount} new, ${dupeCount} duplicates skipped (seenIds: ${seenIds.size}, pendingIds: ${pendingIds.size})`);
   }
 
   sessionCount += newCount;


### PR DESCRIPTION
I had a bug where some posts are added to seenIds without being actually scraped. The post id was showing up in debug logs as DEDUPLICATED, but post was not present in scraped jsonl files.

This might be an edge case around creating a new post. Restarting the browser fixed the issue

I let codex come up with a fix, but I don't have a way to be sure because I can't repro it again. Leaving this to you, you can treat this as a prompt request and close if it's slop

Clanker notes:

## Summary
- keep newly seen tweet IDs in an in-memory `pendingIds` set while they are buffered
- promote IDs from `pendingIds` to persisted `seenIds` only after a successful batch send
- deduplicate against both `seenIds` and `pendingIds` to prevent within-session duplicates
- document the updated dedup lifecycle in `README.md` and `AGENTS.md`

## Why
`seenIds` were previously updated before durable write completion. If the worker restarted before flush, a tweet could be missing on disk but still deduplicated later.

## Validation
- `node --check background.js`
- `node --test tests/tweet-parser.test.mjs`
- `python3 -m pytest tests/ -v` *(not run: `pytest` is not installed in this environment)*