### PR TITLE
Add first-class Firefox support (manifest, installers, runtime compat)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
         run: python3 -m pytest tests/test_xtap_core.py -v --cov --cov-report=xml:coverage-python.xml
 
       - name: Run JS tests with coverage
-        run: npx c8 --reporter=lcov --report-dir=coverage-js node --test tests/tweet-parser.test.mjs
+        run: npx c8 --reporter=lcov --report-dir=coverage-js node --test tests/*.test.mjs
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,7 +180,7 @@ X sometimes returns `TimelineTweet` entries where `tweet_results.result` is miss
 ## Development Notes
 
 - **No build step** — plain JS, no bundler, no transpilation. Load and go.
-- **Testing:** `python3 -m pytest tests/ -v && node --test tests/tweet-parser.test.mjs`. Run after every change. CI runs these on every push to main with coverage uploaded to Codecov. For manual browser testing, load unpacked in Chrome (`chrome://extensions`) or as a temporary add-on in Firefox (`about:debugging#/runtime/this-firefox`) using `manifest.firefox.json`. Chrome extension IDs vary per install; Firefox uses the fixed Gecko ID in `manifest.firefox.json`. Use the matching installer mode (`install.sh ... chrome|firefox`, `install.ps1 -Browser chrome|firefox`).
+- **Testing:** `python3 -m pytest tests/ -v && node --test tests/*.test.mjs`. Run after every change. CI runs these on every push to main with coverage uploaded to Codecov. For manual browser testing, load unpacked in Chrome (`chrome://extensions`) or as a temporary add-on in Firefox (`about:debugging#/runtime/this-firefox`) using `manifest.firefox.json`. Chrome extension IDs vary per install; Firefox uses the fixed Gecko ID in `manifest.firefox.json`. Use the matching installer mode (`install.sh ... chrome|firefox`, `install.ps1 -Browser chrome|firefox`).
 - **Debugging:** Enable "Debug logging to file" in the debug dashboard (popup → "Debug Dashboard"). Logs write to `debug-YYYY-MM-DD.log` in the output directory. Service worker console is visible in each browser's extension debugger. The debug dashboard also shows live capture events with accept/dedup/error status, transport health, and a parser sandbox for testing `extractTweets` against raw JSON.
 - **Dev mode seenIds:** In dev mode, `seenIds` uses `chrome.storage.session` when available (volatile — clears on extension reload). If session storage APIs are unavailable, it safely falls back to `chrome.storage.local`.
 - **tweet-parser.js** is the most fragile file — it handles multiple GraphQL response shapes and X changes their API schema without notice. The recursive fallback (`findInstructionsRecursive`) catches many new endpoint shapes automatically, but field-level changes to tweet objects will need manual updates to `normalizeTweet()`.
@@ -191,7 +191,7 @@ X sometimes returns `TimelineTweet` entries where `tweet_results.result` is miss
 ## Contributing
 
 - Keep it simple. No build tools, no frameworks, no dependencies beyond Python 3 stdlib.
-- Run `python3 -m pytest tests/ -v && node --test tests/tweet-parser.test.mjs` before submitting changes.
+- Run `python3 -m pytest tests/ -v && node --test tests/*.test.mjs` before submitting changes.
 - Every change must maintain zero network footprint. This is the core promise.
 - Stealth constraints are non-negotiable — review the list above before submitting changes.
 - **Update README.md and AGENTS.md after every relevant change** — new features, changed behavior, new config options, output format changes, new endpoints, architectural changes, etc. Both files must stay in sync with the code.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## What This Is
 
-xTap is a Chrome extension that passively captures tweets from X/Twitter by intercepting GraphQL API responses the browser already receives. No scraping, no extra requests — just structured JSONL output of what the user sees.
+xTap is a browser extension (Chrome + Firefox) that passively captures tweets from X/Twitter by intercepting GraphQL API responses the browser already receives. No scraping, no extra requests — just structured JSONL output of what the user sees.
 
 **Repo:** github.com/mkubicek/xTap
 **License:** MIT (public repo)
@@ -34,7 +34,7 @@ background.js (Service Worker, ES module)
 └────────────────────────────────────────────────────────────────┘
 ┌─── Native messaging (bootstrap + fallback) ───────────────────┐
 │ xtap_host.py (Python, stdio)                                   │
-│   Chrome native messaging protocol                             │
+│   Browser native messaging protocol (Chrome/Firefox)           │
 │   Also serves GET_TOKEN to bootstrap HTTP transport            │
 └────────────────────────────────────────────────────────────────┘
   │  Both use shared logic from xtap_core.py
@@ -45,9 +45,9 @@ debug-YYYY-MM-DD.log     (when debug logging enabled)
 
 ### Key Design Decisions
 
-- **Two content scripts (MAIN + ISOLATED):** Chrome MV3 requires this split. MAIN world can patch browser APIs but can't use chrome.runtime. ISOLATED world bridges the gap.
+- **Two content scripts (MAIN + ISOLATED):** MV3 requires this split. MAIN world can patch browser APIs but can't use chrome.runtime. ISOLATED world bridges the gap.
 - **Random event channel:** The CustomEvent name is generated per page load (`'_' + Math.random().toString(36).slice(2)`) and passed via a `<meta>` tag that's immediately removed. Avoids predictable DOM markers.
-- **Dual transport (HTTP + native messaging):** The HTTP daemon (`xtap_daemon.py`) is managed by launchd (macOS), systemd (Linux), or Scheduled Task (Windows). On macOS, it additionally runs outside Chrome's TCC sandbox, allowing writes to protected paths. At startup, the extension connects to the native host to request `GET_TOKEN` (reads `~/.xtap/secret`), then uses that token for HTTP transport. If HTTP is unavailable, native messaging serves as the data transport fallback.
+- **Dual transport (HTTP + native messaging):** The HTTP daemon (`xtap_daemon.py`) is managed by launchd (macOS), systemd (Linux), or Scheduled Task (Windows). On macOS, it additionally runs outside browser TCC sandboxes, allowing writes to protected paths. At startup, the extension connects to the native host to request `GET_TOKEN` (reads `~/.xtap/secret`), then uses that token for HTTP transport. If HTTP is unavailable, native messaging serves as the data transport fallback.
 - **Token bootstrap:** On first run with the daemon installed, the extension connects to the native host once to request `GET_TOKEN`, which reads `~/.xtap/secret`. The token is cached in `chrome.storage.local` and used for subsequent HTTP requests. The native port is then disconnected.
 - **Shared core logic:** `xtap_core.py` contains all file I/O logic (load seen IDs, resolve output dir, write tweets/logs, test path), used by both `xtap_host.py` and `xtap_daemon.py`.
 - **Environment detection:** `isDevMode = !chrome.runtime.getManifest().update_url` — packed CWS extensions have `update_url`, unpacked don't. Used to switch seenIds storage between session (dev) and local (production).
@@ -76,7 +76,8 @@ debug-YYYY-MM-DD.log     (when debug logging enabled)
 
 ```
 xTap/
-├── manifest.json              # MV3 manifest (permissions: storage, nativeMessaging)
+├── manifest.json              # Chrome MV3 manifest (permissions: storage, nativeMessaging)
+├── manifest.firefox.json      # Firefox MV3 manifest (Gecko ID + min version)
 ├── background.js              # Service worker (ES module) - transport, parsing, dedup
 ├── content-main.js            # MAIN world - fetch/XHR patching
 ├── content-bridge.js          # ISOLATED world - event relay
@@ -91,7 +92,8 @@ xTap/
     ├── xtap_daemon.py            # HTTP daemon (127.0.0.1:17381)
     ├── com.xtap.daemon.plist     # launchd plist template (macOS)
     ├── com.xtap.daemon.service   # systemd unit template (Linux)
-    ├── com.xtap.host.json        # Native messaging host manifest
+    ├── com.xtap.host.json        # Native messaging host manifest (Chrome)
+    ├── com.xtap.host.firefox.json # Native messaging host manifest (Firefox)
     ├── install.sh                # macOS/Linux installer (+ daemon)
     ├── install.ps1               # Windows installer (+ daemon)
     ├── xtap_host.bat             # Windows native host wrapper
@@ -165,9 +167,9 @@ Notes: `media[].duration_ms` only present for videos. `views` may be `null`. For
 
 ### macOS TCC (Transparency, Consent, and Control)
 
-On macOS, Chrome's native messaging host inherits Chrome's TCC sandbox. After Chrome restarts, writes to protected paths (`~/Documents`, iCloud Drive, etc.) can fail with `PermissionError`.
+On macOS, native messaging hosts can inherit browser TCC sandbox restrictions. After browser restarts, writes to protected paths (`~/Documents`, iCloud Drive, etc.) can fail with `PermissionError`.
 
-**Solution:** The HTTP daemon (`xtap_daemon.py`) runs via launchd, independent of Chrome's process tree. It has its own TCC entitlements and can write to protected paths after a one-time macOS permission prompt. The extension automatically uses the daemon when available, falling back to native messaging otherwise.
+**Solution:** The HTTP daemon (`xtap_daemon.py`) runs via launchd, independent of the browser process tree. It has its own TCC entitlements and can write to protected paths after a one-time macOS permission prompt. The extension automatically uses the daemon when available, falling back to native messaging otherwise.
 
 If falling back to native messaging, `~/Downloads/xtap` is the safe default (no TCC required). The path validation feature catches permission errors at save time.
 
@@ -178,9 +180,9 @@ X sometimes returns `TimelineTweet` entries where `tweet_results.result` is miss
 ## Development Notes
 
 - **No build step** — plain JS, no bundler, no transpilation. Load and go.
-- **Testing:** `python3 -m pytest tests/ -v && node --test tests/tweet-parser.test.mjs`. Run after every change. CI runs these on every push to main with coverage uploaded to Codecov. For manual browser testing, load unpacked at `chrome://extensions` with Developer mode. The extension ID changes per install — update `com.xtap.host.json` and re-run the install script.
-- **Debugging:** Enable "Debug logging to file" in the debug dashboard (popup → "Debug Dashboard"). Logs write to `debug-YYYY-MM-DD.log` in the output directory. Service worker console is also visible at `chrome://extensions` → xTap → "Inspect views: service worker". The debug dashboard also shows live capture events with accept/dedup/error status, transport health, and a parser sandbox for testing `extractTweets` against raw JSON.
-- **Dev mode seenIds:** When loaded unpacked, `seenIds` uses `chrome.storage.session` (volatile — clears on extension reload). This avoids manual storage clearing between test runs. Check `isDevMode` in the service worker console to verify.
+- **Testing:** `python3 -m pytest tests/ -v && node --test tests/tweet-parser.test.mjs`. Run after every change. CI runs these on every push to main with coverage uploaded to Codecov. For manual browser testing, load unpacked in Chrome (`chrome://extensions`) or as a temporary add-on in Firefox (`about:debugging#/runtime/this-firefox`) using `manifest.firefox.json`. Chrome extension IDs vary per install; Firefox uses the fixed Gecko ID in `manifest.firefox.json`. Use the matching installer mode (`install.sh ... chrome|firefox`, `install.ps1 -Browser chrome|firefox`).
+- **Debugging:** Enable "Debug logging to file" in the debug dashboard (popup → "Debug Dashboard"). Logs write to `debug-YYYY-MM-DD.log` in the output directory. Service worker console is visible in each browser's extension debugger. The debug dashboard also shows live capture events with accept/dedup/error status, transport health, and a parser sandbox for testing `extractTweets` against raw JSON.
+- **Dev mode seenIds:** In dev mode, `seenIds` uses `chrome.storage.session` when available (volatile — clears on extension reload). If session storage APIs are unavailable, it safely falls back to `chrome.storage.local`.
 - **tweet-parser.js** is the most fragile file — it handles multiple GraphQL response shapes and X changes their API schema without notice. The recursive fallback (`findInstructionsRecursive`) catches many new endpoint shapes automatically, but field-level changes to tweet objects will need manual updates to `normalizeTweet()`.
 - **Service worker module:** `background.js` is loaded as an ES module (`"type": "module"` in manifest). It imports `tweet-parser.js` directly.
 - **HTTP daemon:** `xtap_daemon.py` binds `127.0.0.1:17381`. Auth token stored at `~/.xtap/secret` (mode 600). Managed by launchd (macOS: `launchctl kickstart -k gui/$(id -u)/com.xtap.daemon`), systemd (Linux: `systemctl --user restart com.xtap.daemon`), or Scheduled Task (Windows: `Stop-ScheduledTask -TaskName xTapDaemon; Start-ScheduledTask -TaskName xTapDaemon`). Logs: macOS/Windows at `~/.xtap/daemon-stderr.log`, Linux via `journalctl --user -u com.xtap.daemon`.

--- a/README.md
+++ b/README.md
@@ -19,18 +19,18 @@
 
 <p align="center">
   <img src="https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-blue" alt="Platform" />
-  <img src="https://img.shields.io/badge/chrome-MV3-green" alt="Chrome MV3" />
+  <img src="https://img.shields.io/badge/browser-Chrome%20%7C%20Firefox-green" alt="Chrome and Firefox" />
   <img src="https://img.shields.io/badge/license-MIT-yellow" alt="MIT License" />
   <a href="https://codecov.io/gh/mkubicek/xTap"><img src="https://codecov.io/gh/mkubicek/xTap/graph/badge.svg" alt="codecov" /></a>
 </p>
 
 ---
 
-xTap is a Chrome extension that silently intercepts the GraphQL API responses X/Twitter already sends to your browser and saves every tweet you encounter as structured JSONL. No scraping, no extra requests — just a tap on the data already flowing through.
+xTap is a browser extension (Chrome + Firefox) that silently intercepts the GraphQL API responses X/Twitter already sends to your browser and saves every tweet you encounter as structured JSONL. No scraping, no extra requests — just a tap on the data already flowing through.
 
 ## Features
 
-- **Zero footprint** — no additional network requests; captures what Chrome already receives
+- **Zero footprint** — no additional network requests; captures what your browser already receives
 - **Structured output** — each tweet saved as a clean JSON object with author, metrics, media, and more
 - **Article support** — long-form X articles are captured with full text, inline image references, and Draft.js block structure
 - **Video download** — download videos from tweets using yt-dlp (or direct MP4 fallback) via the extension popup. Requires the HTTP daemon. **Note:** unlike passive capture, video downloads make additional network requests to X and are not stealth.
@@ -81,8 +81,8 @@ xTap is a Chrome extension that silently intercepts the GraphQL API responses X/
 2. Payloads are relayed via a random-named `CustomEvent` to an ISOLATED world bridge, which forwards them to the service worker
 3. The service worker parses, normalizes, deduplicates, and batches tweets
 4. Batches are sent to disk via one of two transports:
-   - **HTTP daemon**: a standalone `xtap_daemon.py` process on `127.0.0.1:17381`, managed by launchd (macOS), systemd (Linux), or Scheduled Task (Windows). On macOS, it runs outside Chrome's TCC sandbox and can write to protected paths like `~/Documents` and iCloud Drive
-   - **Native messaging**: `xtap_host.py` over Chrome's stdio protocol — used at startup to retrieve the daemon's auth token (`GET_TOKEN`), and as a data transport fallback if HTTP is unavailable
+   - **HTTP daemon**: a standalone `xtap_daemon.py` process on `127.0.0.1:17381`, managed by launchd (macOS), systemd (Linux), or Scheduled Task (Windows). On macOS, it runs outside browser TCC sandboxes and can write to protected paths like `~/Documents` and iCloud Drive
+   - **Native messaging**: `xtap_host.py` over browser native messaging (Chrome/Firefox) — used at startup to retrieve the daemon's auth token (`GET_TOKEN`), and as a data transport fallback if HTTP is unavailable
 
 ## Is This Safe to Use?
 
@@ -113,17 +113,28 @@ These measures don't make detection impossible — a determined page script coul
 
 | | Requirement |
 |---|---|
-| **Browser** | Google Chrome |
+| **Browser** | Google Chrome or Mozilla Firefox |
 | **Runtime** | Python 3 |
 | **OS** | macOS, Linux, or Windows |
 | [`yt-dlp`](https://github.com/yt-dlp/yt-dlp#installation) (optional) | For best-quality video downloads |
 
 ### 1. Load the extension
 
+For Chrome:
 1. Open `chrome://extensions`
 2. Enable **Developer mode** (top right)
 3. Click **Load unpacked** and select the `xtap/` directory
-4. Copy the **extension ID** shown on the card
+4. Copy the extension ID shown on the card (used by native host install)
+
+For Firefox:
+1. Create a Firefox copy of the extension directory (so your Chrome manifest stays unchanged)
+2. In that copy, replace `manifest.json` with `manifest.firefox.json` (rename it to `manifest.json`)
+3. Open `about:debugging#/runtime/this-firefox`
+4. Click **Load Temporary Add-on...**
+5. Select the Firefox copy's `manifest.json`
+
+Firefox uses the fixed extension ID from `manifest.firefox.json`: `xtap@mkubicek.dev`.
+Firefox version requirement: 128+ (MV3 `MAIN` world content scripts).
 
 ### 2. Install the native host
 
@@ -132,10 +143,17 @@ These measures don't make detection impossible — a determined page script coul
 
 ```bash
 cd native-host
-./install.sh <your-extension-id>
+./install.sh <your-extension-id> chrome
 ```
 
-This installs the native messaging host and an HTTP daemon (`xtap_daemon.py`) that runs via launchd. The daemon runs independently of Chrome's process tree and has its own TCC permissions, so it can write to protected paths like `~/Documents` and iCloud Drive. The installer captures your current `PATH` so the daemon can find tools like `yt-dlp`.
+For Firefox use:
+
+```bash
+cd native-host
+./install.sh firefox
+```
+
+This installs the native messaging host and an HTTP daemon (`xtap_daemon.py`) that runs via launchd. The daemon runs independently of the browser process tree and has its own TCC permissions, so it can write to protected paths like `~/Documents` and iCloud Drive. The installer captures your current `PATH` so the daemon can find tools like `yt-dlp`.
 
 The extension automatically detects the daemon and uses it as the primary transport, falling back to native messaging if unavailable.
 
@@ -146,7 +164,14 @@ The extension automatically detects the daemon and uses it as the primary transp
 
 ```bash
 cd native-host
-./install.sh <your-extension-id>
+./install.sh <your-extension-id> chrome
+```
+
+For Firefox use:
+
+```bash
+cd native-host
+./install.sh firefox
 ```
 
 This installs the native messaging host and an HTTP daemon (`xtap_daemon.py`) that runs as a systemd user service. The daemon enables video downloads and provides the same HTTP transport as macOS.
@@ -158,7 +183,14 @@ This installs the native messaging host and an HTTP daemon (`xtap_daemon.py`) th
 
 ```powershell
 cd native-host
-.\install.ps1 <your-extension-id>
+.\install.ps1 -ExtensionId <your-extension-id> -Browser chrome
+```
+
+For Firefox use:
+
+```powershell
+cd native-host
+.\install.ps1 -Browser firefox
 ```
 
 This installs the native messaging host and an HTTP daemon (`xtap_daemon.py`) as a Windows Scheduled Task that starts at logon. The daemon enables video downloads and provides the same HTTP transport as macOS/Linux.
@@ -169,13 +201,13 @@ This installs the native messaging host and an HTTP daemon (`xtap_daemon.py`) as
 
 Open [x.com](https://x.com) and browse normally. The badge counter on the extension icon shows how many tweets have been captured this session. Click the icon to see stats and pause/resume capture.
 
-> **After updating the extension:** If you reload xTap at `chrome://extensions`, you must also hard-reload any open X tabs (`Cmd+Shift+R` / `Ctrl+Shift+R`). The content scripts that intercept API responses are injected at page load — stale scripts from before the update won't connect to the new service worker.
+> **After updating the extension:** Reload xTap in your extension manager (`chrome://extensions` or `about:debugging#/runtime/this-firefox`), then hard-reload any open X tabs (`Cmd+Shift+R` / `Ctrl+Shift+R`). The content scripts that intercept API responses are injected at page load, so stale scripts from before the update won't connect to the new service worker.
 
 ### Upgrading from a previous version
 
 After updating the extension files:
 1. Re-run the installer (`install.sh` on macOS/Linux, `install.ps1` on Windows) — this updates the daemon's PATH (required for yt-dlp support) and picks up new Python code
-2. Reload the extension at `chrome://extensions`
+2. Reload the extension in your browser extension manager
 3. Hard-reload any open X tabs (`Cmd+Shift+R` / `Ctrl+Shift+R`)
 
 If you previously installed xTap before v0.13.0 on macOS, re-running `install.sh` is **required** for video download support — the daemon needs an updated launchd configuration to find yt-dlp on your PATH. On Linux and Windows, the daemon is new in this version — running the installer will set it up automatically.
@@ -186,7 +218,7 @@ If you previously installed xTap before v0.13.0 on macOS, re-running `install.sh
 
 The easiest way to change where tweets are saved is through the extension popup — click the xTap icon and enter your preferred path in the **Output directory** field.
 
-Alternatively, set the `XTAP_OUTPUT_DIR` environment variable before launching Chrome:
+Alternatively, set the `XTAP_OUTPUT_DIR` environment variable before launching your browser:
 
 ```bash
 export XTAP_OUTPUT_DIR="$HOME/Documents/xtap-data"
@@ -198,7 +230,7 @@ export XTAP_OUTPUT_DIR="$HOME/Documents/xtap-data"
 | `XTAP_OUTPUT_DIR` env var | `~/Downloads/xtap` | Fallback when no popup setting is configured |
 | Debug Dashboard | — | Accessible via popup link; shows live capture events, transport health, debug logging and discovery mode toggles, and parser sandbox |
 
-> **macOS note:** On macOS, the HTTP daemon (installed via `install.sh`) runs outside Chrome's TCC sandbox and can write to protected paths like `~/Documents` and iCloud Drive after a one-time macOS permission prompt. If the daemon is unavailable and the extension falls back to native messaging, protected paths will fail with a permission error — `~/Downloads` is the safe default in that case.
+> **macOS note:** On macOS, the HTTP daemon (installed via `install.sh`) runs outside browser TCC sandboxes and can write to protected paths like `~/Documents` and iCloud Drive after a one-time macOS permission prompt. If the daemon is unavailable and the extension falls back to native messaging, protected paths will fail with a permission error — `~/Downloads` is the safe default in that case.
 
 ## Output Format
 
@@ -263,6 +295,7 @@ For regular tweets, `is_article` and `article` are absent. For articles, `text` 
 ```
 xTap/
 ├── manifest.json              # Chrome MV3 extension manifest
+├── manifest.firefox.json      # Firefox MV3 extension manifest (Gecko ID + min version)
 ├── background.js              # Service worker — parsing, dedup, transport
 ├── content-main.js            # MAIN world — patches fetch/XHR, emits events
 ├── content-bridge.js          # ISOLATED world — relays events to service worker
@@ -276,6 +309,8 @@ xTap/
     ├── xtap_daemon.py            # HTTP daemon
     ├── com.xtap.daemon.plist     # launchd plist template (macOS)
     ├── com.xtap.daemon.service   # systemd unit template (Linux)
+    ├── com.xtap.host.json        # Native host manifest template (Chrome)
+    ├── com.xtap.host.firefox.json # Native host manifest template (Firefox)
     ├── install.sh                # Installer for macOS / Linux
     ├── install.ps1               # Installer for Windows
     ├── xtap_host.bat             # Windows native host wrapper
@@ -284,13 +319,13 @@ xTap/
 
 ## Development
 
-After modifying extension files (`background.js`, `lib/`, `content-*.js`, `popup.*`), reload the extension at `chrome://extensions` and hard-reload any open X tabs.
+After modifying extension files (`background.js`, `lib/`, `content-*.js`, `popup.*`), reload the extension in your browser (`chrome://extensions` or `about:debugging#/runtime/this-firefox`) and hard-reload any open X tabs.
 
 **Debug dashboard:** Click "Debug Dashboard" in the popup to open a live view of capture events, transport health, and a parser sandbox for testing `extractTweets` against raw GraphQL JSON. Debug logging and discovery mode toggles are also here — enable debug logging to write timestamped service worker logs to `debug-YYYY-MM-DD.log`, or discovery mode to log endpoint response shapes to the console.
 
-**Dev mode:** When loaded unpacked (developer mode), the extension uses `chrome.storage.session` for the `seenIds` dedup cache instead of `chrome.storage.local`. This means reloading the extension automatically clears the cache — no need to manually clear storage between test runs. Production (CWS) behavior is unchanged.
+**Dev mode:** When loaded unpacked (developer mode), the extension prefers `chrome.storage.session` for the `seenIds` dedup cache, and falls back to `chrome.storage.local` if session storage APIs are unavailable. When session storage is available, reloading the extension automatically clears the cache — no need to manually clear storage between test runs.
 
-After modifying Python host files (`xtap_core.py`, `xtap_host.py`, `xtap_daemon.py`), the native host picks up changes on next Chrome restart. To restart the HTTP daemon immediately:
+After modifying Python host files (`xtap_core.py`, `xtap_host.py`, `xtap_daemon.py`), the native host picks up changes on next browser restart. To restart the HTTP daemon immediately:
 
 **macOS (launchd):**
 ```bash

--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ Get-Content ~\.xtap\daemon-stderr.log -Tail 50 -Wait                            
 
 ```bash
 python3 -m pytest tests/test_xtap_core.py -v
-node --test tests/tweet-parser.test.mjs
+node --test tests/*.test.mjs
 ```
 
 CI runs these on every push to `main` with coverage uploaded to [Codecov](https://codecov.io/gh/mkubicek/xTap).

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ For Chrome:
 4. Copy the extension ID shown on the card (used by native host install)
 
 For Firefox:
+Thanks [Vincent Koc](https://github.com/vincentkoc) for the Firefox support contribution.
 1. Create a Firefox copy of the extension directory (so your Chrome manifest stays unchanged)
 2. In that copy, replace `manifest.json` with `manifest.firefox.json` (rename it to `manifest.json`)
 3. Open `about:debugging#/runtime/this-firefox`

--- a/background.js
+++ b/background.js
@@ -19,6 +19,8 @@ let debugLogging = false;
 let verboseLogging = false;
 let logBuffer = [];
 const isDevMode = !chrome.runtime.getManifest().update_url;
+const hasSessionStorage = !!chrome.storage.session;
+const traceStorage = chrome.storage.session || chrome.storage.local;
 let readyResolve;
 const ready = new Promise(r => { readyResolve = r; });
 
@@ -37,12 +39,12 @@ let httpPort = null;
 // --- State persistence ---
 
 function seenIdsStorage() {
-  return isDevMode ? chrome.storage.session : chrome.storage.local;
+  return (isDevMode && hasSessionStorage) ? chrome.storage.session : chrome.storage.local;
 }
 
 async function saveState() {
   const seenData = { seenIds: [...seenIds].slice(-MAX_SEEN_IDS) };
-  if (isDevMode) {
+  if (isDevMode && hasSessionStorage) {
     await Promise.all([
       chrome.storage.session.set(seenData),
       chrome.storage.local.set({ allTimeCount, captureEnabled }),
@@ -105,10 +107,19 @@ async function httpFetch(method, path, body) {
   }
 }
 
+function makeTimeoutSignal(ms) {
+  if (typeof AbortSignal !== 'undefined' && typeof AbortSignal.timeout === 'function') {
+    return AbortSignal.timeout(ms);
+  }
+  const controller = new AbortController();
+  setTimeout(() => controller.abort(), ms);
+  return controller.signal;
+}
+
 async function probeHttp(port, token) {
   try {
     const resp = await fetch(`http://127.0.0.1:${port}/status`, {
-      signal: AbortSignal.timeout(3000)
+      signal: makeTimeoutSignal(3000)
     });
     const data = await resp.json();
     return data.ok === true;
@@ -348,7 +359,7 @@ function emitTraceEvent(event) {
   if (!traceFlushTimer) {
     traceFlushTimer = setTimeout(() => {
       traceFlushTimer = null;
-      chrome.storage.session.set({ lastEvents: traceEvents });
+      traceStorage.set({ lastEvents: traceEvents });
     }, 500);
   }
 }
@@ -678,7 +689,9 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
 
 // --- Init ---
 
-chrome.storage.session.setAccessLevel({ accessLevel: 'TRUSTED_AND_UNTRUSTED_CONTEXTS' });
+if (typeof chrome.storage.session?.setAccessLevel === 'function') {
+  chrome.storage.session.setAccessLevel({ accessLevel: 'TRUSTED_AND_UNTRUSTED_CONTEXTS' });
+}
 
 restoreState().then(async () => {
   readyResolve();
@@ -689,5 +702,6 @@ restoreState().then(async () => {
     flushTimer = setTimeout(() => { scheduledFlush(); scheduleNextFlush(); }, FLUSH_INTERVAL_MS + jitter);
   }
   scheduleNextFlush();
-  console.log(`[xTap] Service worker started (${isDevMode ? 'dev' : 'production'} mode, seenIds in ${isDevMode ? 'session' : 'local'} storage)`);
+  const seenStorageLabel = (isDevMode && hasSessionStorage) ? 'session' : 'local';
+  console.log(`[xTap] Service worker started (${isDevMode ? 'dev' : 'production'} mode, seenIds in ${seenStorageLabel} storage)`);
 });

--- a/background.js
+++ b/background.js
@@ -1,5 +1,6 @@
 // xTap — Service Worker (background)
 import { extractTweets } from './lib/tweet-parser.js';
+import { storageGet, storageSet } from './lib/storage-compat.js';
 
 const NATIVE_HOST = 'com.xtap.host';
 const BATCH_SIZE = 50;
@@ -46,18 +47,18 @@ async function saveState() {
   const seenData = { seenIds: [...seenIds].slice(-MAX_SEEN_IDS) };
   if (isDevMode && hasSessionStorage) {
     await Promise.all([
-      chrome.storage.session.set(seenData),
-      chrome.storage.local.set({ allTimeCount, captureEnabled }),
+      storageSet(chrome.storage.session, seenData, chrome.runtime),
+      storageSet(chrome.storage.local, { allTimeCount, captureEnabled }, chrome.runtime),
     ]);
   } else {
-    await chrome.storage.local.set({ ...seenData, allTimeCount, captureEnabled });
+    await storageSet(chrome.storage.local, { ...seenData, allTimeCount, captureEnabled }, chrome.runtime);
   }
 }
 
 async function restoreState() {
   const [seenStored, stored] = await Promise.all([
-    seenIdsStorage().get(['seenIds']),
-    chrome.storage.local.get(['allTimeCount', 'captureEnabled', 'outputDir', 'debugLogging', 'verboseLogging']),
+    storageGet(seenIdsStorage(), ['seenIds'], chrome.runtime),
+    storageGet(chrome.storage.local, ['allTimeCount', 'captureEnabled', 'outputDir', 'debugLogging', 'verboseLogging'], chrome.runtime),
   ]);
   if (seenStored.seenIds) seenIds = new Set(seenStored.seenIds);
   if (typeof stored.allTimeCount === 'number') allTimeCount = stored.allTimeCount;
@@ -164,7 +165,7 @@ async function getTokenViaNative() {
 
 async function initTransport() {
   // 1. Check cached token
-  const cached = await chrome.storage.local.get(['httpToken', 'httpPort']);
+  const cached = await storageGet(chrome.storage.local, ['httpToken', 'httpPort'], chrome.runtime);
   if (cached.httpToken && cached.httpPort) {
     const alive = await probeHttp(cached.httpPort, cached.httpToken);
     if (alive) {
@@ -184,7 +185,7 @@ async function initTransport() {
       httpToken = result.token;
       httpPort = result.port;
       transport = 'http';
-      await chrome.storage.local.set({ httpToken, httpPort });
+      await storageSet(chrome.storage.local, { httpToken, httpPort }, chrome.runtime);
       console.log('[xTap] Using HTTP transport (token from native host)');
       return;
     }
@@ -693,7 +694,9 @@ if (typeof chrome.storage.session?.setAccessLevel === 'function') {
   chrome.storage.session.setAccessLevel({ accessLevel: 'TRUSTED_AND_UNTRUSTED_CONTEXTS' });
 }
 
-restoreState().then(async () => {
+restoreState().catch((e) => {
+  console.error('[xTap] Failed to restore state:', e);
+}).then(async () => {
   readyResolve();
   updateBadge();
   await initTransport();

--- a/debug.js
+++ b/debug.js
@@ -47,6 +47,8 @@ const eventsBody = document.getElementById('events-body');
 const autoScrollCheckbox = document.getElementById('auto-scroll');
 const clearBtn = document.getElementById('clear-events');
 const eventsWrap = document.querySelector('.events-wrap');
+const traceStorage = chrome.storage.session || chrome.storage.local;
+const traceArea = chrome.storage.session ? 'session' : 'local';
 
 let renderedCount = 0;
 
@@ -80,13 +82,13 @@ function appendEventRow(ev) {
 }
 
 // Load initial events
-chrome.storage.session.get(['lastEvents'], (result) => {
+traceStorage.get(['lastEvents'], (result) => {
   if (result.lastEvents) renderEvents(result.lastEvents);
 });
 
 // Live updates
 chrome.storage.onChanged.addListener((changes, area) => {
-  if (area === 'session' && changes.lastEvents) {
+  if (area === traceArea && changes.lastEvents) {
     const events = changes.lastEvents.newValue || [];
     // Re-render if the new batch has fewer (was trimmed) or is a fresh set
     if (events.length <= renderedCount || events.length === 0) {
@@ -104,7 +106,7 @@ chrome.storage.onChanged.addListener((changes, area) => {
 clearBtn.addEventListener('click', () => {
   eventsBody.innerHTML = '';
   renderedCount = 0;
-  chrome.storage.session.set({ lastEvents: [] });
+  traceStorage.set({ lastEvents: [] });
 });
 
 // --- Parser sandbox ---

--- a/lib/storage-compat.js
+++ b/lib/storage-compat.js
@@ -1,0 +1,69 @@
+// Storage API compatibility helpers for callback-only and promise-based
+// extension runtimes (Chrome/Firefox variations).
+
+function runtimeFrom(runtimeLike) {
+  if (runtimeLike) return runtimeLike;
+  return globalThis.chrome?.runtime || null;
+}
+
+export function storageGet(area, keys, runtimeLike) {
+  const runtime = runtimeFrom(runtimeLike);
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const finish = (value) => {
+      if (settled) return;
+      settled = true;
+      const err = runtime?.lastError;
+      if (err) reject(new Error(err.message));
+      else resolve(value || {});
+    };
+    try {
+      const maybePromise = area.get(keys, finish);
+      if (maybePromise && typeof maybePromise.then === 'function') {
+        maybePromise.then((value) => finish(value)).catch(reject);
+      }
+    } catch (_firstErr) {
+      try {
+        const maybePromise = area.get(keys);
+        if (maybePromise && typeof maybePromise.then === 'function') {
+          maybePromise.then((value) => finish(value)).catch(reject);
+        } else {
+          finish({});
+        }
+      } catch (err) {
+        reject(err);
+      }
+    }
+  });
+}
+
+export function storageSet(area, value, runtimeLike) {
+  const runtime = runtimeFrom(runtimeLike);
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      const err = runtime?.lastError;
+      if (err) reject(new Error(err.message));
+      else resolve();
+    };
+    try {
+      const maybePromise = area.set(value, finish);
+      if (maybePromise && typeof maybePromise.then === 'function') {
+        maybePromise.then(() => finish()).catch(reject);
+      }
+    } catch (_firstErr) {
+      try {
+        const maybePromise = area.set(value);
+        if (maybePromise && typeof maybePromise.then === 'function') {
+          maybePromise.then(() => finish()).catch(reject);
+        } else {
+          finish();
+        }
+      } catch (err) {
+        reject(err);
+      }
+    }
+  });
+}

--- a/manifest.firefox.json
+++ b/manifest.firefox.json
@@ -6,7 +6,7 @@
   "permissions": ["storage", "nativeMessaging"],
   "host_permissions": ["*://*.x.com/*", "*://*.twitter.com/*", "http://127.0.0.1/*"],
   "background": {
-    "service_worker": "background.js",
+    "scripts": ["background.js"],
     "type": "module"
   },
   "content_scripts": [

--- a/manifest.firefox.json
+++ b/manifest.firefox.json
@@ -1,0 +1,45 @@
+{
+  "manifest_version": 3,
+  "name": "xTap",
+  "version": "0.17.1",
+  "description": "Passively captures tweets from X/Twitter as you browse",
+  "permissions": ["storage", "nativeMessaging"],
+  "host_permissions": ["*://*.x.com/*", "*://*.twitter.com/*", "http://127.0.0.1/*"],
+  "background": {
+    "service_worker": "background.js",
+    "type": "module"
+  },
+  "content_scripts": [
+    {
+      "matches": ["*://*.x.com/*", "*://*.twitter.com/*"],
+      "js": ["content-main.js"],
+      "world": "MAIN",
+      "run_at": "document_start"
+    },
+    {
+      "matches": ["*://*.x.com/*", "*://*.twitter.com/*"],
+      "js": ["content-bridge.js"],
+      "world": "ISOLATED",
+      "run_at": "document_start"
+    }
+  ],
+  "action": {
+    "default_popup": "popup.html",
+    "default_icon": {
+      "16": "icons/icon16.png",
+      "48": "icons/icon48.png",
+      "128": "icons/icon128.png"
+    }
+  },
+  "icons": {
+    "16": "icons/icon16.png",
+    "48": "icons/icon48.png",
+    "128": "icons/icon128.png"
+  },
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "xtap@mkubicek.dev",
+      "strict_min_version": "128.0"
+    }
+  }
+}

--- a/native-host/com.xtap.host.firefox.json
+++ b/native-host/com.xtap.host.firefox.json
@@ -1,0 +1,7 @@
+{
+  "name": "com.xtap.host",
+  "description": "xTap native messaging host — writes captured tweets to JSONL",
+  "path": "/path/to/xtap_host.py",
+  "type": "stdio",
+  "allowed_extensions": ["xtap@mkubicek.dev"]
+}

--- a/native-host/install.ps1
+++ b/native-host/install.ps1
@@ -1,9 +1,15 @@
 # xTap — Windows installer for the native messaging host (PowerShell).
-# Usage: .\install.ps1 <chrome-extension-id>
+# Usage:
+#   .\install.ps1 -ExtensionId <id> [-Browser chrome|firefox]
+#   .\install.ps1 -Browser firefox
 
 param(
-    [Parameter(Mandatory=$true, Position=0)]
-    [string]$ExtensionId
+    [Parameter(Mandatory=$false, Position=0)]
+    [string]$ExtensionId,
+
+    [Parameter(Mandatory=$false)]
+    [ValidateSet("chrome", "firefox")]
+    [string]$Browser = "chrome"
 )
 
 $ErrorActionPreference = "Stop"
@@ -13,7 +19,20 @@ $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
 $HostPy = Join-Path $ScriptDir "xtap_host.py"
 $BatPath = Join-Path $ScriptDir "xtap_host.bat"
 $ManifestPath = Join-Path $ScriptDir "$HostName.json"
-$RegKey = "HKCU:\Software\Google\Chrome\NativeMessagingHosts\$HostName"
+
+if (-not $ExtensionId -and $Browser -eq "firefox") {
+    $ExtensionId = "xtap@mkubicek.dev"
+}
+if (-not $ExtensionId) {
+    Write-Error "ExtensionId is required for Chrome installs (find it at chrome://extensions)."
+    exit 1
+}
+
+$RegKey = if ($Browser -eq "firefox") {
+    "HKCU:\Software\Mozilla\NativeMessagingHosts\$HostName"
+} else {
+    "HKCU:\Software\Google\Chrome\NativeMessagingHosts\$HostName"
+}
 
 # Verify python
 if (-not (Get-Command python -ErrorAction SilentlyContinue)) {
@@ -22,13 +41,18 @@ if (-not (Get-Command python -ErrorAction SilentlyContinue)) {
 }
 
 # Write manifest (path must point to the .bat wrapper)
-$manifest = @{
+$manifestData = @{
     name = $HostName
     description = "xTap native messaging host -- writes captured tweets to JSONL"
     path = $BatPath
     type = "stdio"
-    allowed_origins = @("chrome-extension://$ExtensionId/")
-} | ConvertTo-Json -Depth 2
+}
+if ($Browser -eq "firefox") {
+    $manifestData.allowed_extensions = @($ExtensionId)
+} else {
+    $manifestData.allowed_origins = @("chrome-extension://$ExtensionId/")
+}
+$manifest = $manifestData | ConvertTo-Json -Depth 2
 
 Set-Content -Path $ManifestPath -Value $manifest -Encoding UTF8
 
@@ -42,6 +66,7 @@ Set-ItemProperty -Path $RegKey -Name "(Default)" -Value $ManifestPath
 Write-Host "Installed native messaging host:"
 Write-Host "  Manifest: $ManifestPath"
 Write-Host "  Registry: $RegKey"
+Write-Host "  Browser: $Browser"
 Write-Host "  Host script: $HostPy"
 Write-Host "  Extension ID: $ExtensionId"
 

--- a/native-host/install.sh
+++ b/native-host/install.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # xTap — installer for the native messaging host and HTTP daemon (macOS / Linux).
-# Usage: ./install.sh <chrome-extension-id>
+# Usage:
+#   ./install.sh <extension-id> [chrome|firefox]
+#   ./install.sh firefox [extension-id]
 
 set -euo pipefail
 
@@ -10,12 +12,42 @@ if [ "$(id -u)" -eq 0 ]; then
 fi
 
 if [ $# -lt 1 ]; then
-  echo "Usage: $0 <chrome-extension-id>"
-  echo "  Find your extension ID at chrome://extensions (enable Developer mode)"
+  echo "Usage:"
+  echo "  $0 <extension-id> [chrome|firefox]"
+  echo "  $0 firefox [extension-id]"
+  echo ""
+  echo "Chrome ID: chrome://extensions (Developer mode)"
+  echo "Firefox ID default: xtap@mkubicek.dev (from manifest.firefox.json)"
   exit 1
 fi
 
-EXT_ID="$1"
+BROWSER="chrome"
+EXT_ID=""
+if [ "$1" = "chrome" ] || [ "$1" = "firefox" ]; then
+  BROWSER="$1"
+  EXT_ID="${2:-}"
+else
+  EXT_ID="$1"
+  if [ $# -ge 2 ]; then
+    BROWSER="$2"
+  fi
+fi
+
+if [ "$BROWSER" != "chrome" ] && [ "$BROWSER" != "firefox" ]; then
+  echo "Error: browser must be 'chrome' or 'firefox'"
+  exit 1
+fi
+
+if [ "$BROWSER" = "firefox" ] && [ -z "$EXT_ID" ]; then
+  EXT_ID="xtap@mkubicek.dev"
+fi
+
+if [ -z "$EXT_ID" ]; then
+  echo "Error: extension ID is required for Chrome installs."
+  echo "Find it at chrome://extensions (enable Developer mode)."
+  exit 1
+fi
+
 HOST_NAME="com.xtap.host"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 HOST_PATH="${SCRIPT_DIR}/xtap_host.py"
@@ -23,10 +55,18 @@ HOST_PATH="${SCRIPT_DIR}/xtap_host.py"
 OS="$(uname)"
 case "$OS" in
   Darwin)
-    TARGET_DIR="$HOME/Library/Application Support/Google/Chrome/NativeMessagingHosts"
+    if [ "$BROWSER" = "firefox" ]; then
+      TARGET_DIR="$HOME/Library/Application Support/Mozilla/NativeMessagingHosts"
+    else
+      TARGET_DIR="$HOME/Library/Application Support/Google/Chrome/NativeMessagingHosts"
+    fi
     ;;
   Linux)
-    TARGET_DIR="$HOME/.config/google-chrome/NativeMessagingHosts"
+    if [ "$BROWSER" = "firefox" ]; then
+      TARGET_DIR="$HOME/.mozilla/native-messaging-hosts"
+    else
+      TARGET_DIR="$HOME/.config/google-chrome/NativeMessagingHosts"
+    fi
     ;;
   *)
     echo "Error: Unsupported OS '$OS'. Use install.ps1 on Windows."
@@ -49,7 +89,18 @@ chmod +x "$HOST_PATH"
 mkdir -p "$TARGET_DIR"
 
 # Write native messaging manifest
-cat > "$MANIFEST_PATH" <<EOF
+if [ "$BROWSER" = "firefox" ]; then
+  cat > "$MANIFEST_PATH" <<EOF
+{
+  "name": "${HOST_NAME}",
+  "description": "xTap native messaging host — writes captured tweets to JSONL",
+  "path": "${HOST_PATH}",
+  "type": "stdio",
+  "allowed_extensions": ["${EXT_ID}"]
+}
+EOF
+else
+  cat > "$MANIFEST_PATH" <<EOF
 {
   "name": "${HOST_NAME}",
   "description": "xTap native messaging host — writes captured tweets to JSONL",
@@ -58,10 +109,12 @@ cat > "$MANIFEST_PATH" <<EOF
   "allowed_origins": ["chrome-extension://${EXT_ID}/"]
 }
 EOF
+fi
 
 echo "Installed native messaging host manifest to:"
 echo "  $MANIFEST_PATH"
 echo ""
+echo "Browser: $BROWSER"
 echo "Host script: $HOST_PATH"
 echo "Extension ID: $EXT_ID"
 

--- a/tests/manifest.firefox.test.mjs
+++ b/tests/manifest.firefox.test.mjs
@@ -1,0 +1,32 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import url from 'node:url';
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const manifestPath = path.resolve(__dirname, '../manifest.firefox.json');
+const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+
+test('Firefox manifest uses background scripts mode', () => {
+  assert.equal(manifest.manifest_version, 3);
+  assert.ok(manifest.background);
+  assert.deepEqual(manifest.background.scripts, ['background.js']);
+  assert.equal(manifest.background.type, 'module');
+  assert.equal(manifest.background.service_worker, undefined);
+});
+
+test('Firefox manifest declares expected Gecko metadata', () => {
+  const gecko = manifest.browser_specific_settings?.gecko;
+  assert.ok(gecko);
+  assert.equal(gecko.id, 'xtap@mkubicek.dev');
+  assert.equal(gecko.strict_min_version, '128.0');
+});
+
+test('Firefox manifest keeps native messaging and site permissions', () => {
+  assert.ok(manifest.permissions.includes('nativeMessaging'));
+  assert.ok(manifest.permissions.includes('storage'));
+  assert.ok(manifest.host_permissions.includes('*://*.x.com/*'));
+  assert.ok(manifest.host_permissions.includes('*://*.twitter.com/*'));
+  assert.ok(manifest.host_permissions.includes('http://127.0.0.1/*'));
+});

--- a/tests/storage-compat.test.mjs
+++ b/tests/storage-compat.test.mjs
@@ -1,0 +1,106 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { storageGet, storageSet } from '../lib/storage-compat.js';
+
+function makeRuntime() {
+  return { lastError: null };
+}
+
+test('storageGet supports callback-style areas', async () => {
+  const runtime = makeRuntime();
+  const area = {
+    get(_keys, cb) {
+      cb({ seenIds: ['1', '2'] });
+    }
+  };
+  const value = await storageGet(area, ['seenIds'], runtime);
+  assert.deepEqual(value, { seenIds: ['1', '2'] });
+});
+
+test('storageGet supports promise-style areas', async () => {
+  const runtime = makeRuntime();
+  const area = {
+    get() {
+      return Promise.resolve({ captureEnabled: true });
+    }
+  };
+  const value = await storageGet(area, ['captureEnabled'], runtime);
+  assert.deepEqual(value, { captureEnabled: true });
+});
+
+test('storageGet falls back to get(keys) when get(keys, cb) throws', async () => {
+  const runtime = makeRuntime();
+  const area = {
+    get(keys, cb) {
+      if (typeof cb === 'function') throw new Error('callback not supported');
+      assert.deepEqual(keys, ['allTimeCount']);
+      return Promise.resolve({ allTimeCount: 42 });
+    }
+  };
+  const value = await storageGet(area, ['allTimeCount'], runtime);
+  assert.deepEqual(value, { allTimeCount: 42 });
+});
+
+test('storageGet rejects when runtime.lastError is set', async () => {
+  const runtime = makeRuntime();
+  const area = {
+    get(_keys, cb) {
+      runtime.lastError = { message: 'get failed' };
+      cb({});
+      runtime.lastError = null;
+    }
+  };
+  await assert.rejects(storageGet(area, ['x'], runtime), /get failed/);
+});
+
+test('storageSet supports callback-style areas', async () => {
+  const runtime = makeRuntime();
+  let saved = null;
+  const area = {
+    set(value, cb) {
+      saved = value;
+      cb();
+    }
+  };
+  await storageSet(area, { debugLogging: true }, runtime);
+  assert.deepEqual(saved, { debugLogging: true });
+});
+
+test('storageSet supports promise-style areas', async () => {
+  const runtime = makeRuntime();
+  let saved = null;
+  const area = {
+    set(value) {
+      saved = value;
+      return Promise.resolve();
+    }
+  };
+  await storageSet(area, { outputDir: '/tmp/x' }, runtime);
+  assert.deepEqual(saved, { outputDir: '/tmp/x' });
+});
+
+test('storageSet falls back to set(value) when set(value, cb) throws', async () => {
+  const runtime = makeRuntime();
+  let saved = null;
+  const area = {
+    set(value, cb) {
+      if (typeof cb === 'function') throw new Error('callback not supported');
+      saved = value;
+      return Promise.resolve();
+    }
+  };
+  await storageSet(area, { httpToken: 'abc' }, runtime);
+  assert.deepEqual(saved, { httpToken: 'abc' });
+});
+
+test('storageSet rejects when runtime.lastError is set', async () => {
+  const runtime = makeRuntime();
+  const area = {
+    set(_value, cb) {
+      runtime.lastError = { message: 'set failed' };
+      cb();
+      runtime.lastError = null;
+    }
+  };
+  await assert.rejects(storageSet(area, { k: 1 }, runtime), /set failed/);
+});


### PR DESCRIPTION
## Summary
This PR adds first-class Firefox support while preserving existing Chrome behavior and stealth constraints.

### What changed
- Added a dedicated Firefox MV3 manifest (`manifest.firefox.json`) with Gecko metadata.
- Switched Firefox background config to `background.scripts` (module) for environments where MV3 service workers are disabled.
- Added Firefox native host manifest template (`native-host/com.xtap.host.firefox.json`).
- Extended native-host installers for Firefox targets:
  - `native-host/install.sh` (`chrome|firefox` mode)
  - `native-host/install.ps1` (`-Browser chrome|firefox`)
- Hardened extension startup/runtime compatibility:
  - storage API compatibility helpers for callback-style vs promise-style runtimes
  - fallback handling for trace/session storage
  - timeout signal fallback when `AbortSignal.timeout` is unavailable
- Added regression tests:
  - Firefox manifest shape/permissions
  - storage compatibility helpers
- Updated docs and CI to run the expanded Node test suite.

## Validation
- `python3 -m pytest tests/ -v`
- `node --test tests/*.test.mjs`
- Manual Firefox smoke test:
  - loads from `about:debugging`
  - background script runs
  - capture counter increments on X scrolling
  - native host writes to disk

<img width="376" height="393" alt="Screenshot 2026-03-02 at 10 41 46" src="https://github.com/user-attachments/assets/f048d06e-7ca5-4599-a0c5-c3541d2b74cc" />

## Notes
- No additional requests are made to X/Twitter endpoints.
- Chrome path remains intact; changes are additive/compatibility-focused.
