### PR TITLE
fix: prevent undefined dedup poisoning and XHR listener stacking

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,5 +1,6 @@
 // xTap — Service Worker (background)
 import { extractTweets } from './lib/tweet-parser.js';
+import { dedupTweet } from './lib/dedup.js';
 
 const NATIVE_HOST = 'com.xtap.host';
 const BATCH_SIZE = 50;
@@ -357,12 +358,10 @@ function enqueueTweets(tweets, endpoint = 'unknown') {
       }
     }
 
-    // Article tweets bypass dedup — they enrich a previously captured stub
-    if (tweet.id && seenIds.has(tweet.id) && !tweet.is_article) {
+    if (!dedupTweet(tweet, seenIds)) {
       emitTraceEvent({ timestamp: Date.now(), endpoint, tweetId: tweet.id, status: 'DEDUPLICATED', reason: 'seenIds' });
       continue;
     }
-    if (tweet.id) seenIds.add(tweet.id);
     buffer.push(tweet);
     newCount++;
     emitTraceEvent({ timestamp: Date.now(), endpoint, tweetId: tweet.id, status: 'ACCEPTED', reason: null });

--- a/background.js
+++ b/background.js
@@ -59,7 +59,7 @@ async function restoreState() {
     seenIdsStorage().get(['seenIds']),
     chrome.storage.local.get(['allTimeCount', 'captureEnabled', 'outputDir', 'debugLogging', 'verboseLogging']),
   ]);
-  if (seenStored.seenIds) seenIds = new Set(seenStored.seenIds);
+  if (seenStored.seenIds) seenIds = new Set(seenStored.seenIds.filter(Boolean));
   if (typeof stored.allTimeCount === 'number') allTimeCount = stored.allTimeCount;
   if (typeof stored.captureEnabled === 'boolean') captureEnabled = stored.captureEnabled;
   if (typeof stored.outputDir === 'string') outputDir = stored.outputDir;

--- a/background.js
+++ b/background.js
@@ -358,11 +358,11 @@ function enqueueTweets(tweets, endpoint = 'unknown') {
     }
 
     // Article tweets bypass dedup — they enrich a previously captured stub
-    if (seenIds.has(tweet.id) && !tweet.is_article) {
+    if (tweet.id && seenIds.has(tweet.id) && !tweet.is_article) {
       emitTraceEvent({ timestamp: Date.now(), endpoint, tweetId: tweet.id, status: 'DEDUPLICATED', reason: 'seenIds' });
       continue;
     }
-    seenIds.add(tweet.id);
+    if (tweet.id) seenIds.add(tweet.id);
     buffer.push(tweet);
     newCount++;
     emitTraceEvent({ timestamp: Date.now(), endpoint, tweetId: tweet.id, status: 'ACCEPTED', reason: null });

--- a/content-main.js
+++ b/content-main.js
@@ -12,6 +12,7 @@
   (document.head || document.documentElement).appendChild(beacon);
 
   const xhrUrls = new WeakMap();
+  const xhrPatched = new WeakSet();
 
   function extractEndpoint(url) {
     try {
@@ -58,12 +59,15 @@
     const urlStr = (typeof url === 'string') ? url : url?.toString();
     if (urlStr && urlStr.includes(GRAPHQL_PATTERN)) {
       xhrUrls.set(this, urlStr);
-      this.addEventListener('load', function () {
-        try {
-          const data = JSON.parse(this.responseText);
-          dispatchData(xhrUrls.get(this), data);
-        } catch (_) {}
-      });
+      if (!xhrPatched.has(this)) {
+        xhrPatched.add(this);
+        this.addEventListener('load', function () {
+          try {
+            const data = JSON.parse(this.responseText);
+            dispatchData(xhrUrls.get(this), data);
+          } catch (_) {}
+        });
+      }
     }
     return nativeOpen.call(this, method, url, ...rest);
   };

--- a/lib/dedup.js
+++ b/lib/dedup.js
@@ -1,0 +1,22 @@
+/**
+ * Tweet deduplication logic.
+ *
+ * Extracted so both background.js and tests can use the same code path.
+ */
+
+/**
+ * Check whether a tweet is new and track it in seenIds.
+ *
+ * Returns true  → tweet is new, should be enqueued.
+ * Returns false → tweet is a duplicate, should be skipped.
+ *
+ * - Tweets without an id are always new (and not tracked).
+ * - Article tweets bypass dedup — they enrich a previously captured stub.
+ */
+export function dedupTweet(tweet, seenIds) {
+  if (tweet.id && seenIds.has(tweet.id) && !tweet.is_article) {
+    return false;
+  }
+  if (tweet.id) seenIds.add(tweet.id);
+  return true;
+}

--- a/tests/dedup-xhr.test.mjs
+++ b/tests/dedup-xhr.test.mjs
@@ -1,0 +1,188 @@
+/**
+ * Tests for issue #10: undefined dedup poisoning + XHR listener stacking
+ * Run with: node --test tests/dedup-xhr.test.mjs
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+// ---------------------------------------------------------------------------
+// Bug 1: seenIds dedup with missing tweet IDs
+//
+// We replicate the enqueueTweets dedup logic here since background.js is a
+// service worker module with chrome.* dependencies that can't be imported
+// directly.
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal replica of the enqueueTweets dedup logic (post-fix).
+ * Returns { buffer, seenIds } after processing.
+ */
+function enqueueTweets(tweets, seenIds = new Set()) {
+  const buffer = [];
+  for (const tweet of tweets) {
+    if (tweet.id && seenIds.has(tweet.id) && !tweet.is_article) {
+      continue;
+    }
+    if (tweet.id) seenIds.add(tweet.id);
+    buffer.push(tweet);
+  }
+  return { buffer, seenIds };
+}
+
+describe('enqueueTweets dedup (Bug 1: undefined poisoning)', () => {
+  it('enqueues a tweet with a missing id', () => {
+    const { buffer, seenIds } = enqueueTweets([{ text: 'no id' }]);
+    assert.equal(buffer.length, 1);
+    assert.equal(buffer[0].text, 'no id');
+    assert.ok(!seenIds.has(undefined), 'seenIds must not contain undefined');
+  });
+
+  it('enqueues multiple tweets with missing ids (not treated as dupes)', () => {
+    const { buffer, seenIds } = enqueueTweets([
+      { text: 'first no-id' },
+      { text: 'second no-id' },
+      { text: 'third no-id' },
+    ]);
+    assert.equal(buffer.length, 3);
+    assert.ok(!seenIds.has(undefined));
+  });
+
+  it('still deduplicates tweets that have an id', () => {
+    const { buffer } = enqueueTweets([
+      { id: '1', text: 'first' },
+      { id: '1', text: 'dupe' },
+      { id: '2', text: 'second' },
+    ]);
+    assert.equal(buffer.length, 2);
+    assert.equal(buffer[0].id, '1');
+    assert.equal(buffer[1].id, '2');
+  });
+
+  it('does not deduplicate article tweets even with same id', () => {
+    const { buffer } = enqueueTweets([
+      { id: '1', text: 'stub' },
+      { id: '1', text: 'full article', is_article: true },
+    ]);
+    assert.equal(buffer.length, 2);
+  });
+
+  it('respects pre-existing seenIds', () => {
+    const seenIds = new Set(['1', '2']);
+    const { buffer } = enqueueTweets([
+      { id: '1', text: 'already seen' },
+      { id: '3', text: 'new' },
+    ], seenIds);
+    assert.equal(buffer.length, 1);
+    assert.equal(buffer[0].id, '3');
+  });
+
+  it('handles a mix of id and no-id tweets', () => {
+    const { buffer, seenIds } = enqueueTweets([
+      { id: '1', text: 'has id' },
+      { text: 'no id' },
+      { id: '1', text: 'dupe' },
+      { text: 'another no id' },
+      { id: '2', text: 'new id' },
+    ]);
+    assert.equal(buffer.length, 4);
+    assert.ok(!seenIds.has(undefined));
+    assert.ok(seenIds.has('1'));
+    assert.ok(seenIds.has('2'));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bug 2: XHR listener stacking on reused instances
+//
+// We replicate the patching logic with a minimal XHR-like object to verify
+// that reused instances only get one listener.
+// ---------------------------------------------------------------------------
+
+describe('XHR listener stacking (Bug 2)', () => {
+  // Minimal XHR stub
+  class FakeXHR {
+    constructor() {
+      this._listeners = {};
+    }
+    addEventListener(event, fn) {
+      if (!this._listeners[event]) this._listeners[event] = [];
+      this._listeners[event].push(fn);
+    }
+    _fireLoad() {
+      for (const fn of (this._listeners.load || [])) fn.call(this);
+    }
+  }
+
+  /**
+   * Replica of the patched open() logic (post-fix).
+   */
+  function makePatchedOpen() {
+    const xhrUrls = new WeakMap();
+    const xhrPatched = new WeakSet();
+    const dispatched = [];
+
+    function patchedOpen(xhr, method, url) {
+      const GRAPHQL_PATTERN = '/i/api/graphql/';
+      const urlStr = (typeof url === 'string') ? url : url?.toString();
+      if (urlStr && urlStr.includes(GRAPHQL_PATTERN)) {
+        xhrUrls.set(xhr, urlStr);
+        if (!xhrPatched.has(xhr)) {
+          xhrPatched.add(xhr);
+          xhr.addEventListener('load', function () {
+            dispatched.push(xhrUrls.get(this));
+          });
+        }
+      }
+    }
+    return { patchedOpen, dispatched };
+  }
+
+  it('single-use XHR emits exactly one event', () => {
+    const { patchedOpen, dispatched } = makePatchedOpen();
+    const xhr = new FakeXHR();
+    patchedOpen(xhr, 'GET', 'https://x.com/i/api/graphql/abc/TweetDetail');
+    xhr._fireLoad();
+    assert.equal(dispatched.length, 1);
+  });
+
+  it('reused XHR (multiple open calls) emits exactly one event per load', () => {
+    const { patchedOpen, dispatched } = makePatchedOpen();
+    const xhr = new FakeXHR();
+    // Simulate reuse: call open() 3 times on the same instance
+    patchedOpen(xhr, 'GET', 'https://x.com/i/api/graphql/abc/TweetDetail');
+    patchedOpen(xhr, 'GET', 'https://x.com/i/api/graphql/def/UserTweets');
+    patchedOpen(xhr, 'GET', 'https://x.com/i/api/graphql/ghi/HomeTimeline');
+    xhr._fireLoad();
+    assert.equal(dispatched.length, 1, 'should only dispatch once despite 3 open() calls');
+  });
+
+  it('reused XHR uses the latest URL', () => {
+    const { patchedOpen, dispatched } = makePatchedOpen();
+    const xhr = new FakeXHR();
+    patchedOpen(xhr, 'GET', 'https://x.com/i/api/graphql/abc/TweetDetail');
+    patchedOpen(xhr, 'GET', 'https://x.com/i/api/graphql/def/UserTweets');
+    xhr._fireLoad();
+    assert.equal(dispatched.length, 1);
+    assert.ok(dispatched[0].includes('/def/UserTweets'), 'should use the URL from the latest open() call');
+  });
+
+  it('different XHR instances each get their own listener', () => {
+    const { patchedOpen, dispatched } = makePatchedOpen();
+    const xhr1 = new FakeXHR();
+    const xhr2 = new FakeXHR();
+    patchedOpen(xhr1, 'GET', 'https://x.com/i/api/graphql/abc/TweetDetail');
+    patchedOpen(xhr2, 'GET', 'https://x.com/i/api/graphql/def/UserTweets');
+    xhr1._fireLoad();
+    xhr2._fireLoad();
+    assert.equal(dispatched.length, 2);
+  });
+
+  it('non-GraphQL URLs are ignored', () => {
+    const { patchedOpen, dispatched } = makePatchedOpen();
+    const xhr = new FakeXHR();
+    patchedOpen(xhr, 'GET', 'https://x.com/i/api/2/timeline');
+    xhr._fireLoad();
+    assert.equal(dispatched.length, 0);
+  });
+});

--- a/tests/dedup-xhr.test.mjs
+++ b/tests/dedup-xhr.test.mjs
@@ -1,91 +1,63 @@
 /**
- * Tests for issue #10: undefined dedup poisoning + XHR listener stacking
+ * Tests for issue #10: undefined dedup poisoning + XHR listener stacking.
  * Run with: node --test tests/dedup-xhr.test.mjs
+ *
+ * Bug 1 tests import the production dedupTweet() from lib/dedup.js.
+ * Bug 2 tests evaluate the production content-main.js IIFE via vm.runInNewContext
+ * with mocked browser globals so the real patching code is exercised.
  */
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { runInNewContext } from 'node:vm';
+import { dedupTweet } from '../lib/dedup.js';
 
 // ---------------------------------------------------------------------------
-// Bug 1: seenIds dedup with missing tweet IDs
-//
-// We replicate the enqueueTweets dedup logic here since background.js is a
-// service worker module with chrome.* dependencies that can't be imported
-// directly.
+// Bug 1: seenIds dedup with missing tweet IDs — tests production dedupTweet()
 // ---------------------------------------------------------------------------
 
-/**
- * Minimal replica of the enqueueTweets dedup logic (post-fix).
- * Returns { buffer, seenIds } after processing.
- */
-function enqueueTweets(tweets, seenIds = new Set()) {
-  const buffer = [];
-  for (const tweet of tweets) {
-    if (tweet.id && seenIds.has(tweet.id) && !tweet.is_article) {
-      continue;
-    }
-    if (tweet.id) seenIds.add(tweet.id);
-    buffer.push(tweet);
-  }
-  return { buffer, seenIds };
-}
-
-describe('enqueueTweets dedup (Bug 1: undefined poisoning)', () => {
-  it('enqueues a tweet with a missing id', () => {
-    const { buffer, seenIds } = enqueueTweets([{ text: 'no id' }]);
-    assert.equal(buffer.length, 1);
-    assert.equal(buffer[0].text, 'no id');
+describe('dedupTweet (Bug 1: undefined poisoning)', () => {
+  it('returns true for a tweet with missing id (enqueue it)', () => {
+    const seenIds = new Set();
+    assert.equal(dedupTweet({ text: 'no id' }, seenIds), true);
     assert.ok(!seenIds.has(undefined), 'seenIds must not contain undefined');
   });
 
-  it('enqueues multiple tweets with missing ids (not treated as dupes)', () => {
-    const { buffer, seenIds } = enqueueTweets([
-      { text: 'first no-id' },
-      { text: 'second no-id' },
-      { text: 'third no-id' },
-    ]);
-    assert.equal(buffer.length, 3);
+  it('enqueues multiple no-id tweets (none treated as dupes)', () => {
+    const seenIds = new Set();
+    assert.equal(dedupTweet({ text: 'first' }, seenIds), true);
+    assert.equal(dedupTweet({ text: 'second' }, seenIds), true);
+    assert.equal(dedupTweet({ text: 'third' }, seenIds), true);
     assert.ok(!seenIds.has(undefined));
   });
 
-  it('still deduplicates tweets that have an id', () => {
-    const { buffer } = enqueueTweets([
-      { id: '1', text: 'first' },
-      { id: '1', text: 'dupe' },
-      { id: '2', text: 'second' },
-    ]);
-    assert.equal(buffer.length, 2);
-    assert.equal(buffer[0].id, '1');
-    assert.equal(buffer[1].id, '2');
+  it('deduplicates tweets that have an id', () => {
+    const seenIds = new Set();
+    assert.equal(dedupTweet({ id: '1', text: 'first' }, seenIds), true);
+    assert.equal(dedupTweet({ id: '1', text: 'dupe' }, seenIds), false);
+    assert.equal(dedupTweet({ id: '2', text: 'second' }, seenIds), true);
   });
 
   it('does not deduplicate article tweets even with same id', () => {
-    const { buffer } = enqueueTweets([
-      { id: '1', text: 'stub' },
-      { id: '1', text: 'full article', is_article: true },
-    ]);
-    assert.equal(buffer.length, 2);
+    const seenIds = new Set();
+    assert.equal(dedupTweet({ id: '1', text: 'stub' }, seenIds), true);
+    assert.equal(dedupTweet({ id: '1', text: 'full article', is_article: true }, seenIds), true);
   });
 
   it('respects pre-existing seenIds', () => {
     const seenIds = new Set(['1', '2']);
-    const { buffer } = enqueueTweets([
-      { id: '1', text: 'already seen' },
-      { id: '3', text: 'new' },
-    ], seenIds);
-    assert.equal(buffer.length, 1);
-    assert.equal(buffer[0].id, '3');
+    assert.equal(dedupTweet({ id: '1', text: 'seen' }, seenIds), false);
+    assert.equal(dedupTweet({ id: '3', text: 'new' }, seenIds), true);
   });
 
   it('handles a mix of id and no-id tweets', () => {
-    const { buffer, seenIds } = enqueueTweets([
-      { id: '1', text: 'has id' },
-      { text: 'no id' },
-      { id: '1', text: 'dupe' },
-      { text: 'another no id' },
-      { id: '2', text: 'new id' },
-    ]);
-    assert.equal(buffer.length, 4);
+    const seenIds = new Set();
+    assert.equal(dedupTweet({ id: '1', text: 'has id' }, seenIds), true);
+    assert.equal(dedupTweet({ text: 'no id' }, seenIds), true);
+    assert.equal(dedupTweet({ id: '1', text: 'dupe' }, seenIds), false);
+    assert.equal(dedupTweet({ text: 'another no id' }, seenIds), true);
+    assert.equal(dedupTweet({ id: '2', text: 'new id' }, seenIds), true);
     assert.ok(!seenIds.has(undefined));
     assert.ok(seenIds.has('1'));
     assert.ok(seenIds.has('2'));
@@ -93,96 +65,133 @@ describe('enqueueTweets dedup (Bug 1: undefined poisoning)', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Bug 2: XHR listener stacking on reused instances
-//
-// We replicate the patching logic with a minimal XHR-like object to verify
-// that reused instances only get one listener.
+// Bug 2: XHR listener stacking — evaluates production content-main.js via vm
 // ---------------------------------------------------------------------------
 
-describe('XHR listener stacking (Bug 2)', () => {
-  // Minimal XHR stub
-  class FakeXHR {
-    constructor() {
-      this._listeners = {};
-    }
-    addEventListener(event, fn) {
-      if (!this._listeners[event]) this._listeners[event] = [];
-      this._listeners[event].push(fn);
-    }
-    _fireLoad() {
-      for (const fn of (this._listeners.load || [])) fn.call(this);
-    }
+const contentMainCode = readFileSync(
+  new URL('../content-main.js', import.meta.url), 'utf8'
+);
+
+/**
+ * Build a minimal browser-like environment for the content-main.js IIFE.
+ * Returns the mock globals and a `dispatched` array that collects every
+ * CustomEvent dispatched to document.
+ */
+function createBrowserEnv() {
+  const dispatched = [];
+
+  function CustomEvent(name, opts) {
+    this.type = name;
+    this.detail = opts?.detail;
   }
 
-  /**
-   * Replica of the patched open() logic (post-fix).
-   */
-  function makePatchedOpen() {
-    const xhrUrls = new WeakMap();
-    const xhrPatched = new WeakSet();
-    const dispatched = [];
+  const document = {
+    createElement: () => ({ name: '', content: '' }),
+    head: { appendChild() {} },
+    documentElement: { appendChild() {} },
+    dispatchEvent(event) {
+      if (event.detail) dispatched.push(JSON.parse(event.detail));
+    },
+  };
 
-    function patchedOpen(xhr, method, url) {
-      const GRAPHQL_PATTERN = '/i/api/graphql/';
-      const urlStr = (typeof url === 'string') ? url : url?.toString();
-      if (urlStr && urlStr.includes(GRAPHQL_PATTERN)) {
-        xhrUrls.set(xhr, urlStr);
-        if (!xhrPatched.has(xhr)) {
-          xhrPatched.add(xhr);
-          xhr.addEventListener('load', function () {
-            dispatched.push(xhrUrls.get(this));
-          });
-        }
-      }
-    }
-    return { patchedOpen, dispatched };
+  function XMLHttpRequest() {
+    this._listeners = {};
+    this.responseText = '';
   }
+  XMLHttpRequest.prototype.addEventListener = function (event, fn) {
+    if (!this._listeners[event]) this._listeners[event] = [];
+    this._listeners[event].push(fn);
+  };
+  XMLHttpRequest.prototype.open = function () {};
+  XMLHttpRequest.prototype.send = function () {};
 
+  const window = { fetch: async () => ({}) };
+  const location = { origin: 'https://x.com' };
+
+  return { document, CustomEvent, XMLHttpRequest, window, location, dispatched };
+}
+
+/** Fire the 'load' event on a mock XHR instance. */
+function fireLoad(xhr, responseText) {
+  xhr.responseText = responseText;
+  for (const fn of (xhr._listeners?.load || [])) fn.call(xhr);
+}
+
+describe('XHR listener stacking — production content-main.js (Bug 2)', () => {
   it('single-use XHR emits exactly one event', () => {
-    const { patchedOpen, dispatched } = makePatchedOpen();
-    const xhr = new FakeXHR();
-    patchedOpen(xhr, 'GET', 'https://x.com/i/api/graphql/abc/TweetDetail');
-    xhr._fireLoad();
-    assert.equal(dispatched.length, 1);
+    const env = createBrowserEnv();
+    runInNewContext(contentMainCode, { ...env, console });
+
+    const xhr = new env.XMLHttpRequest();
+    env.XMLHttpRequest.prototype.open.call(
+      xhr, 'GET', 'https://x.com/i/api/graphql/abc/TweetDetail'
+    );
+    fireLoad(xhr, JSON.stringify({ data: {} }));
+    assert.equal(env.dispatched.length, 1);
   });
 
   it('reused XHR (multiple open calls) emits exactly one event per load', () => {
-    const { patchedOpen, dispatched } = makePatchedOpen();
-    const xhr = new FakeXHR();
-    // Simulate reuse: call open() 3 times on the same instance
-    patchedOpen(xhr, 'GET', 'https://x.com/i/api/graphql/abc/TweetDetail');
-    patchedOpen(xhr, 'GET', 'https://x.com/i/api/graphql/def/UserTweets');
-    patchedOpen(xhr, 'GET', 'https://x.com/i/api/graphql/ghi/HomeTimeline');
-    xhr._fireLoad();
-    assert.equal(dispatched.length, 1, 'should only dispatch once despite 3 open() calls');
+    const env = createBrowserEnv();
+    runInNewContext(contentMainCode, { ...env, console });
+
+    const xhr = new env.XMLHttpRequest();
+    env.XMLHttpRequest.prototype.open.call(
+      xhr, 'GET', 'https://x.com/i/api/graphql/abc/TweetDetail'
+    );
+    env.XMLHttpRequest.prototype.open.call(
+      xhr, 'GET', 'https://x.com/i/api/graphql/def/UserTweets'
+    );
+    env.XMLHttpRequest.prototype.open.call(
+      xhr, 'GET', 'https://x.com/i/api/graphql/ghi/HomeTimeline'
+    );
+    fireLoad(xhr, JSON.stringify({ data: {} }));
+    assert.equal(env.dispatched.length, 1,
+      'should dispatch exactly once despite 3 open() calls');
   });
 
   it('reused XHR uses the latest URL', () => {
-    const { patchedOpen, dispatched } = makePatchedOpen();
-    const xhr = new FakeXHR();
-    patchedOpen(xhr, 'GET', 'https://x.com/i/api/graphql/abc/TweetDetail');
-    patchedOpen(xhr, 'GET', 'https://x.com/i/api/graphql/def/UserTweets');
-    xhr._fireLoad();
-    assert.equal(dispatched.length, 1);
-    assert.ok(dispatched[0].includes('/def/UserTweets'), 'should use the URL from the latest open() call');
+    const env = createBrowserEnv();
+    runInNewContext(contentMainCode, { ...env, console });
+
+    const xhr = new env.XMLHttpRequest();
+    env.XMLHttpRequest.prototype.open.call(
+      xhr, 'GET', 'https://x.com/i/api/graphql/abc/TweetDetail'
+    );
+    env.XMLHttpRequest.prototype.open.call(
+      xhr, 'GET', 'https://x.com/i/api/graphql/def/UserTweets'
+    );
+    fireLoad(xhr, JSON.stringify({ data: {} }));
+    assert.equal(env.dispatched.length, 1);
+    assert.ok(env.dispatched[0].url.includes('/def/UserTweets'),
+      'should use the URL from the latest open() call');
   });
 
   it('different XHR instances each get their own listener', () => {
-    const { patchedOpen, dispatched } = makePatchedOpen();
-    const xhr1 = new FakeXHR();
-    const xhr2 = new FakeXHR();
-    patchedOpen(xhr1, 'GET', 'https://x.com/i/api/graphql/abc/TweetDetail');
-    patchedOpen(xhr2, 'GET', 'https://x.com/i/api/graphql/def/UserTweets');
-    xhr1._fireLoad();
-    xhr2._fireLoad();
-    assert.equal(dispatched.length, 2);
+    const env = createBrowserEnv();
+    runInNewContext(contentMainCode, { ...env, console });
+
+    const xhr1 = new env.XMLHttpRequest();
+    const xhr2 = new env.XMLHttpRequest();
+    env.XMLHttpRequest.prototype.open.call(
+      xhr1, 'GET', 'https://x.com/i/api/graphql/abc/TweetDetail'
+    );
+    env.XMLHttpRequest.prototype.open.call(
+      xhr2, 'GET', 'https://x.com/i/api/graphql/def/UserTweets'
+    );
+    fireLoad(xhr1, JSON.stringify({ data: {} }));
+    fireLoad(xhr2, JSON.stringify({ data: {} }));
+    assert.equal(env.dispatched.length, 2);
   });
 
   it('non-GraphQL URLs are ignored', () => {
-    const { patchedOpen, dispatched } = makePatchedOpen();
-    const xhr = new FakeXHR();
-    patchedOpen(xhr, 'GET', 'https://x.com/i/api/2/timeline');
-    xhr._fireLoad();
-    assert.equal(dispatched.length, 0);
+    const env = createBrowserEnv();
+    runInNewContext(contentMainCode, { ...env, console });
+
+    const xhr = new env.XMLHttpRequest();
+    env.XMLHttpRequest.prototype.open.call(
+      xhr, 'GET', 'https://x.com/i/api/2/timeline'
+    );
+    fireLoad(xhr, JSON.stringify({ data: {} }));
+    assert.equal(env.dispatched.length, 0);
   });
 });


### PR DESCRIPTION
## Summary

- Guard `seenIds` operations with `tweet.id` truthiness so `undefined` is never added to the dedup set — tweets without IDs are still enqueued normally
- Track patched XHR instances with a `WeakSet` so reused instances only get one `load` listener regardless of how many times `open()` is called
- Add 11 tests covering both bugs

Closes #10

## Test plan

- [x] `node --test tests/dedup-xhr.test.mjs` — 11 new tests pass
- [x] `node --test tests/tweet-parser.test.mjs tests/manifest.test.mjs` — 58 existing tests pass, no regressions
- [ ] Manual smoke test: browse X/Twitter timeline, verify tweets still captured normally