### PR TITLE
fix: harden daemon request path

### DIFF
--- a/native-host/xtap_daemon.py
+++ b/native-host/xtap_daemon.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """xTap HTTP Daemon — runs as a system service (launchd/systemd/Scheduled Task)."""
 
+import hmac
 import json
 import os
 import platform
@@ -17,6 +18,7 @@ from xtap_core import (DEFAULT_OUTPUT_DIR, load_seen_ids, resolve_output_dir,
 VERSION = '0.19.1'
 BIND_HOST = '127.0.0.1'
 BIND_PORT = 17381
+MAX_BODY_SIZE = 10 * 1024 * 1024  # 10 MB
 XTAP_DIR = os.path.expanduser('~/.xtap')
 XTAP_SECRET = os.path.join(XTAP_DIR, 'secret')
 
@@ -62,15 +64,14 @@ class DaemonHandler(BaseHTTPRequestHandler):
         self.wfile.write(body)
         log_debug(f'  -> {status} ({len(body)} bytes)')
 
-    def _read_json(self):
-        length = int(self.headers.get('Content-Length', 0))
+    def _read_json(self, length):
         if length == 0:
             return {}
         return json.loads(self.rfile.read(length))
 
     def _check_auth(self):
         auth = self.headers.get('Authorization', '')
-        if not auth.startswith('Bearer ') or auth[7:] != _token:
+        if not auth.startswith('Bearer ') or not hmac.compare_digest(auth[7:], _token):
             log_debug(f'  Auth failed (header {"present" if auth else "missing"})')
             self._send_json({'ok': False, 'error': 'Unauthorized'}, 401)
             return False
@@ -83,13 +84,37 @@ class DaemonHandler(BaseHTTPRequestHandler):
             return
         self._send_json({'ok': False, 'error': 'Not found'}, 404)
 
+    def _validate_content_length(self):
+        """Validate Content-Length header. Returns length or -1 on error (response already sent)."""
+        raw = self.headers.get('Content-Length')
+        if raw is None:
+            self._send_json({'ok': False, 'error': 'Missing Content-Length header'}, 400)
+            return -1
+        try:
+            length = int(raw)
+        except ValueError:
+            self._send_json({'ok': False, 'error': f'Invalid Content-Length: {raw!r}'}, 400)
+            return -1
+        if length < 0:
+            self._send_json({'ok': False, 'error': 'Content-Length must not be negative'}, 400)
+            return -1
+        if length > MAX_BODY_SIZE:
+            self._send_json({'ok': False, 'error': 'Payload too large'}, 413)
+            return -1
+        return length
+
     def do_POST(self):
-        log_debug(f'POST {self.path} (Content-Length: {self.headers.get("Content-Length", "0")})')
+        log_debug(f'POST {self.path} (Content-Length: {self.headers.get("Content-Length", "?")})')
+
+        length = self._validate_content_length()
+        if length < 0:
+            return
+
         if not self._check_auth():
             return
 
         try:
-            body = self._read_json()
+            body = self._read_json(length)
         except (json.JSONDecodeError, ValueError) as e:
             self._send_json({'ok': False, 'error': f'Invalid JSON: {e}'}, 400)
             return

--- a/tests/test_xtap_daemon.py
+++ b/tests/test_xtap_daemon.py
@@ -1,0 +1,225 @@
+"""Tests for native-host/xtap_daemon.py — request hardening (issue #7)."""
+
+import json
+import os
+import sys
+import threading
+
+import pytest
+import urllib.request
+import urllib.error
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'native-host'))
+import xtap_daemon
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+TEST_TOKEN = 'test-token-for-daemon'
+
+
+@pytest.fixture(autouse=True)
+def _set_module_token():
+    """Inject a known token into the daemon module for all tests."""
+    old = xtap_daemon._token
+    xtap_daemon._token = TEST_TOKEN
+    yield
+    xtap_daemon._token = old
+
+
+@pytest.fixture()
+def daemon_url():
+    """Start DaemonHandler on an ephemeral port and return its base URL."""
+    from http.server import HTTPServer
+    server = HTTPServer(('127.0.0.1', 0), xtap_daemon.DaemonHandler)
+    port = server.server_address[1]
+    t = threading.Thread(target=server.serve_forever, daemon=True)
+    t.start()
+    yield f'http://127.0.0.1:{port}'
+    server.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _post(base_url, path='/', body=None, token=None, headers=None):
+    """Send a POST request and return (status, parsed_json)."""
+    data = json.dumps(body).encode() if body is not None else b''
+    req = urllib.request.Request(f'{base_url}{path}', data=data, method='POST')
+    req.add_header('Content-Type', 'application/json')
+    if token is not None:
+        req.add_header('Authorization', f'Bearer {token}')
+    if headers:
+        for k, v in headers.items():
+            req.add_header(k, v)
+    # Content-Length is set automatically by urllib from data
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return resp.status, json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        return e.code, json.loads(e.read())
+
+
+def _raw_post(base_url, path='/', raw_body=b'', token=None, content_length=None):
+    """Send a POST with explicit Content-Length control."""
+    req = urllib.request.Request(f'{base_url}{path}', data=raw_body, method='POST')
+    req.add_header('Content-Type', 'application/json')
+    if token is not None:
+        req.add_header('Authorization', f'Bearer {token}')
+    if content_length is not None:
+        req.add_header('Content-Length', str(content_length))
+    # Remove auto-set Content-Length so our override takes effect
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return resp.status, json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        return e.code, json.loads(e.read())
+
+
+# ---------------------------------------------------------------------------
+# Tests — Content-Length validation
+# ---------------------------------------------------------------------------
+
+class TestContentLengthValidation:
+
+    def test_missing_content_length(self, daemon_url):
+        """POST without Content-Length should return 400."""
+        import http.client
+        conn = http.client.HTTPConnection('127.0.0.1', int(daemon_url.rsplit(':', 1)[1]))
+        conn.putrequest('POST', '/tweets')
+        conn.putheader('Content-Type', 'application/json')
+        conn.putheader('Authorization', f'Bearer {TEST_TOKEN}')
+        conn.endheaders()
+        resp = conn.getresponse()
+        body = json.loads(resp.read())
+        assert resp.status == 400
+        assert 'Missing Content-Length' in body['error']
+        conn.close()
+
+    def test_non_numeric_content_length(self, daemon_url):
+        """Non-numeric Content-Length should return 400."""
+        import http.client
+        conn = http.client.HTTPConnection('127.0.0.1', int(daemon_url.rsplit(':', 1)[1]))
+        conn.putrequest('POST', '/tweets')
+        conn.putheader('Content-Type', 'application/json')
+        conn.putheader('Content-Length', 'abc')
+        conn.putheader('Authorization', f'Bearer {TEST_TOKEN}')
+        conn.endheaders()
+        resp = conn.getresponse()
+        body = json.loads(resp.read())
+        assert resp.status == 400
+        assert 'Invalid Content-Length' in body['error']
+        conn.close()
+
+    def test_negative_content_length(self, daemon_url):
+        """Negative Content-Length should return 400."""
+        import http.client
+        conn = http.client.HTTPConnection('127.0.0.1', int(daemon_url.rsplit(':', 1)[1]))
+        conn.putrequest('POST', '/tweets')
+        conn.putheader('Content-Type', 'application/json')
+        conn.putheader('Content-Length', '-1')
+        conn.putheader('Authorization', f'Bearer {TEST_TOKEN}')
+        conn.endheaders()
+        resp = conn.getresponse()
+        body = json.loads(resp.read())
+        assert resp.status == 400
+        assert 'negative' in body['error'].lower()
+        conn.close()
+
+    def test_oversized_content_length(self, daemon_url):
+        """Content-Length exceeding MAX_BODY_SIZE should return 413."""
+        import http.client
+        huge_length = xtap_daemon.MAX_BODY_SIZE + 1
+        conn = http.client.HTTPConnection('127.0.0.1', int(daemon_url.rsplit(':', 1)[1]))
+        conn.putrequest('POST', '/tweets')
+        conn.putheader('Content-Type', 'application/json')
+        conn.putheader('Content-Length', str(huge_length))
+        conn.putheader('Authorization', f'Bearer {TEST_TOKEN}')
+        conn.endheaders()
+        resp = conn.getresponse()
+        body = json.loads(resp.read())
+        assert resp.status == 413
+        assert 'too large' in body['error'].lower()
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Tests — Auth
+# ---------------------------------------------------------------------------
+
+class TestAuth:
+
+    def test_unauthorized_request_rejected(self, daemon_url):
+        """POST without token should return 401."""
+        status, body = _post(daemon_url, '/tweets', body={'tweets': []})
+        assert status == 401
+        assert body['error'] == 'Unauthorized'
+
+    def test_wrong_token_rejected(self, daemon_url):
+        """POST with wrong token should return 401."""
+        status, body = _post(daemon_url, '/tweets', body={'tweets': []}, token='wrong-token')
+        assert status == 401
+        assert body['error'] == 'Unauthorized'
+
+    def test_content_length_checked_before_auth(self, daemon_url):
+        """Oversized request should be rejected with 413 even without auth."""
+        import http.client
+        huge_length = xtap_daemon.MAX_BODY_SIZE + 1
+        conn = http.client.HTTPConnection('127.0.0.1', int(daemon_url.rsplit(':', 1)[1]))
+        conn.putrequest('POST', '/tweets')
+        conn.putheader('Content-Type', 'application/json')
+        conn.putheader('Content-Length', str(huge_length))
+        # No Authorization header
+        conn.endheaders()
+        resp = conn.getresponse()
+        body = json.loads(resp.read())
+        # Should get 413, not 401
+        assert resp.status == 413
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Tests — Normal authorized request
+# ---------------------------------------------------------------------------
+
+class TestAuthorizedRequest:
+
+    def test_status_endpoint(self, daemon_url):
+        """GET /status should work (no auth, no body)."""
+        req = urllib.request.Request(f'{daemon_url}/status')
+        with urllib.request.urlopen(req) as resp:
+            body = json.loads(resp.read())
+        assert resp.status == 200
+        assert body['ok'] is True
+        assert 'version' in body
+
+    def test_valid_post_succeeds(self, daemon_url, tmp_path, monkeypatch):
+        """An authorized POST /tweets with valid body should succeed."""
+        monkeypatch.setattr(xtap_daemon, '_seen_ids', set())
+        monkeypatch.setattr(xtap_daemon, '_custom_dirs', set())
+        # Point resolve_output_dir to tmp_path
+        import xtap_core
+        monkeypatch.setattr(xtap_core, 'DEFAULT_OUTPUT_DIR', str(tmp_path))
+
+        status, body = _post(
+            daemon_url, '/tweets',
+            body={'tweets': [{'id': '1', 'text': 'hello'}]},
+            token=TEST_TOKEN,
+        )
+        assert status == 200
+        assert body['ok'] is True
+        assert body['count'] == 1
+
+    def test_zero_content_length_post(self, daemon_url):
+        """POST with Content-Length: 0 and valid auth should parse as empty body."""
+        status, body = _post(
+            daemon_url, '/tweets',
+            body={},  # empty dict → Content-Length will be 2 (for "{}")
+            token=TEST_TOKEN,
+        )
+        # Should reach the handler (200 or 500 depending on output dir, but not 400/413)
+        assert status != 400
+        assert status != 413

--- a/tests/test_xtap_daemon.py
+++ b/tests/test_xtap_daemon.py
@@ -196,17 +196,11 @@ class TestAuthorizedRequest:
         assert body['ok'] is True
         assert 'version' in body
 
-    def test_valid_post_succeeds(self, daemon_url, tmp_path, monkeypatch):
+    def test_valid_post_succeeds(self, daemon_url, tmp_path):
         """An authorized POST /tweets with valid body should succeed."""
-        monkeypatch.setattr(xtap_daemon, '_seen_ids', set())
-        monkeypatch.setattr(xtap_daemon, '_custom_dirs', set())
-        # Point resolve_output_dir to tmp_path
-        import xtap_core
-        monkeypatch.setattr(xtap_core, 'DEFAULT_OUTPUT_DIR', str(tmp_path))
-
         status, body = _post(
             daemon_url, '/tweets',
-            body={'tweets': [{'id': '1', 'text': 'hello'}]},
+            body={'outputDir': str(tmp_path), 'tweets': [{'id': '1', 'text': 'hello'}]},
             token=TEST_TOKEN,
         )
         assert status == 200

--- a/tests/test_xtap_daemon.py
+++ b/tests/test_xtap_daemon.py
@@ -208,12 +208,18 @@ class TestAuthorizedRequest:
         assert body['count'] == 1
 
     def test_zero_content_length_post(self, daemon_url):
-        """POST with Content-Length: 0 and valid auth should parse as empty body."""
-        status, body = _post(
-            daemon_url, '/tweets',
-            body={},  # empty dict → Content-Length will be 2 (for "{}")
-            token=TEST_TOKEN,
-        )
-        # Should reach the handler (200 or 500 depending on output dir, but not 400/413)
-        assert status != 400
-        assert status != 413
+        """POST with Content-Length: 0 exercises _read_json returning {}."""
+        import http.client
+        port = int(daemon_url.rsplit(':', 1)[1])
+        conn = http.client.HTTPConnection('127.0.0.1', port)
+        # Use /check-ytdlp which ignores the body — avoids output-dir issues
+        conn.putrequest('POST', '/check-ytdlp')
+        conn.putheader('Content-Type', 'application/json')
+        conn.putheader('Content-Length', '0')
+        conn.putheader('Authorization', f'Bearer {TEST_TOKEN}')
+        conn.endheaders()
+        resp = conn.getresponse()
+        body = json.loads(resp.read())
+        assert resp.status == 200
+        assert body['ok'] is True
+        conn.close()


### PR DESCRIPTION
## Summary
- Enforce 10 MB `Content-Length` cap — rejects oversized requests with `413` before reading the body
- Validate `Content-Length` early in `do_POST` (before auth) — missing, non-numeric, or negative values return `400` with descriptive errors
- Use `hmac.compare_digest` for constant-time token comparison in `_check_auth`

Closes #7

## Test plan
- [x] Missing Content-Length → 400
- [x] Non-numeric Content-Length → 400
- [x] Negative Content-Length → 400
- [x] Oversized Content-Length → 413 (before auth check)
- [x] Unauthorized request → 401
- [x] Wrong token → 401
- [x] Valid authorized POST succeeds
- [x] GET /status unaffected
- [x] All 43 existing tests still pass