### PR TITLE
fix: sandbox outputDir path validation

### DIFF
--- a/native-host/xtap_core.py
+++ b/native-host/xtap_core.py
@@ -14,6 +14,35 @@ from datetime import date
 
 DEFAULT_OUTPUT_DIR = os.environ.get('XTAP_OUTPUT_DIR', os.path.expanduser('~/Downloads/xtap'))
 
+# Allowed roots for outputDir validation: user's home + DEFAULT_OUTPUT_DIR
+# (the latter covers XTAP_OUTPUT_DIR pointing outside home, e.g. /data/xtap)
+_ALLOWED_ROOTS = tuple(dict.fromkeys([
+    os.path.realpath(os.path.expanduser('~')),
+    os.path.realpath(DEFAULT_OUTPUT_DIR),
+]))
+
+
+def validate_output_dir(path):
+    """Validate that a resolved path is under an allowed root directory.
+
+    Args:
+        path: The path to validate (should already be expanduser'd).
+
+    Returns:
+        The realpath-resolved path.
+
+    Raises:
+        ValueError: If the path resolves outside all allowed roots.
+    """
+    resolved = os.path.realpath(path)
+    for root in _ALLOWED_ROOTS:
+        # Append os.sep so '/home/userX' doesn't match root '/home/user'
+        if resolved == root or resolved.startswith(root + os.sep):
+            return resolved
+    raise ValueError(
+        f'outputDir resolves outside allowed directories: {resolved}'
+    )
+
 
 def load_seen_ids(out_dir):
     """Build a set of tweet IDs from all existing JSONL files in the output directory."""
@@ -39,7 +68,7 @@ def resolve_output_dir(msg_dir, default_dir, seen_ids, custom_dirs):
     Returns the resolved output directory path.
     """
     if msg_dir:
-        out_dir = os.path.expanduser(msg_dir)
+        out_dir = validate_output_dir(os.path.expanduser(msg_dir))
         os.makedirs(out_dir, exist_ok=True)
         if out_dir != default_dir and out_dir not in custom_dirs:
             seen_ids.update(load_seen_ids(out_dir))

--- a/native-host/xtap_core.py
+++ b/native-host/xtap_core.py
@@ -107,7 +107,11 @@ def write_log(lines, out_dir):
 
 def write_dump(filename, content, out_dir):
     """Write a raw JSON dump file for discovery/debugging."""
-    dump_file = os.path.join(out_dir, filename)
+    # Strip path components — only the basename is allowed
+    safe_name = os.path.basename(filename)
+    if not safe_name:
+        raise ValueError(f'Invalid dump filename: {filename!r}')
+    dump_file = os.path.join(out_dir, safe_name)
     with open(dump_file, 'w') as f:
         f.write(content)
     return dump_file

--- a/native-host/xtap_core.py
+++ b/native-host/xtap_core.py
@@ -109,7 +109,7 @@ def write_dump(filename, content, out_dir):
     """Write a raw JSON dump file for discovery/debugging."""
     # Strip path components — only the basename is allowed
     safe_name = os.path.basename(filename)
-    if not safe_name:
+    if not safe_name or safe_name in ('.', '..'):
         raise ValueError(f'Invalid dump filename: {filename!r}')
     dump_file = os.path.join(out_dir, safe_name)
     with open(dump_file, 'w') as f:

--- a/native-host/xtap_daemon.py
+++ b/native-host/xtap_daemon.py
@@ -11,7 +11,8 @@ import uuid
 from http.server import HTTPServer, BaseHTTPRequestHandler
 
 from xtap_core import (DEFAULT_OUTPUT_DIR, load_seen_ids, resolve_output_dir,
-                       write_tweets, write_log, write_dump, test_path,
+                       validate_output_dir, write_tweets, write_log,
+                       write_dump, test_path,
                        check_ytdlp, start_download, get_download_status)
 
 VERSION = '0.19.1'
@@ -122,6 +123,8 @@ class DaemonHandler(BaseHTTPRequestHandler):
             count, dupes = write_tweets(tweets, out_dir, _seen_ids)
             log_debug(f'  Tweets: {count} written, {dupes} dupes -> {out_dir}')
             self._send_json({'ok': True, 'count': count, 'dupes': dupes})
+        except ValueError as e:
+            self._send_json({'ok': False, 'error': str(e)}, 400)
         except Exception as e:
             log_info(f'ERROR /tweets: {e}')
             log_debug(f'  Traceback: {_format_exc()}')
@@ -134,6 +137,8 @@ class DaemonHandler(BaseHTTPRequestHandler):
             lines = body.get('lines', [])
             logged = write_log(lines, out_dir)
             self._send_json({'ok': True, 'logged': logged})
+        except ValueError as e:
+            self._send_json({'ok': False, 'error': str(e)}, 400)
         except Exception as e:
             log_info(f'ERROR /log: {e}')
             log_debug(f'  Traceback: {_format_exc()}')
@@ -147,6 +152,8 @@ class DaemonHandler(BaseHTTPRequestHandler):
             content = body.get('content', '')
             path = write_dump(filename, content, out_dir)
             self._send_json({'ok': True, 'path': path})
+        except ValueError as e:
+            self._send_json({'ok': False, 'error': str(e)}, 400)
         except Exception as e:
             log_info(f'ERROR /dump: {e}')
             log_debug(f'  Traceback: {_format_exc()}')
@@ -158,9 +165,11 @@ class DaemonHandler(BaseHTTPRequestHandler):
             if not msg_dir:
                 self._send_json({'ok': False, 'error': 'outputDir is required'}, 400)
                 return
-            out_dir = os.path.expanduser(msg_dir)
+            out_dir = validate_output_dir(os.path.expanduser(msg_dir))
             test_path(out_dir)
             self._send_json({'ok': True, 'type': 'TEST_PATH'})
+        except ValueError as e:
+            self._send_json({'ok': False, 'error': str(e)}, 400)
         except Exception as e:
             log_info(f'ERROR /test-path: {e}')
             self._send_json({'ok': False, 'error': str(e)}, 500)
@@ -181,6 +190,8 @@ class DaemonHandler(BaseHTTPRequestHandler):
             start_download(download_id, tweet_url, direct_url, out_dir, post_date)
             log_debug(f'  Download started: {download_id} -> {tweet_url}')
             self._send_json({'ok': True, 'downloadId': download_id})
+        except ValueError as e:
+            self._send_json({'ok': False, 'error': str(e)}, 400)
         except Exception as e:
             log_info(f'ERROR /download-video: {e}')
             self._send_json({'ok': False, 'error': str(e)}, 500)

--- a/tests/test_xtap_core.py
+++ b/tests/test_xtap_core.py
@@ -299,6 +299,22 @@ class TestWriteDump:
         xtap_core.write_dump('test.json', 'new', str(tmp_path))
         assert (tmp_path / 'test.json').read_text() == 'new'
 
+    def test_traversal_filename_stripped(self, tmp_path):
+        path = xtap_core.write_dump('../../.ssh/authorized_keys', 'data', str(tmp_path))
+        # Traversal stripped — writes to out_dir/authorized_keys
+        assert path == os.path.join(str(tmp_path), 'authorized_keys')
+        assert (tmp_path / 'authorized_keys').read_text() == 'data'
+
+    def test_absolute_filename_stripped(self, tmp_path):
+        path = xtap_core.write_dump('/etc/cron.d/evil', 'data', str(tmp_path))
+        # Should write to out_dir/evil, not /etc/cron.d/evil
+        assert path == os.path.join(str(tmp_path), 'evil')
+        assert (tmp_path / 'evil').read_text() == 'data'
+
+    def test_empty_filename_rejected(self, tmp_path):
+        with pytest.raises(ValueError, match='Invalid dump filename'):
+            xtap_core.write_dump('', 'data', str(tmp_path))
+
 
 # ---------------------------------------------------------------------------
 # test_path

--- a/tests/test_xtap_core.py
+++ b/tests/test_xtap_core.py
@@ -315,6 +315,14 @@ class TestWriteDump:
         with pytest.raises(ValueError, match='Invalid dump filename'):
             xtap_core.write_dump('', 'data', str(tmp_path))
 
+    def test_dot_filename_rejected(self, tmp_path):
+        with pytest.raises(ValueError, match='Invalid dump filename'):
+            xtap_core.write_dump('.', 'data', str(tmp_path))
+
+    def test_dotdot_filename_rejected(self, tmp_path):
+        with pytest.raises(ValueError, match='Invalid dump filename'):
+            xtap_core.write_dump('..', 'data', str(tmp_path))
+
 
 # ---------------------------------------------------------------------------
 # test_path

--- a/tests/test_xtap_core.py
+++ b/tests/test_xtap_core.py
@@ -170,23 +170,24 @@ class TestResolveOutputDir:
         result = xtap_core.resolve_output_dir(None, default, set(), set())
         assert result == default
 
-    def test_custom_dir_created(self, tmp_path):
+    def test_custom_dir_created(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(xtap_core, '_ALLOWED_ROOTS', (os.path.realpath(str(tmp_path)),))
         custom = str(tmp_path / 'custom')
         seen = set()
         custom_dirs = set()
         result = xtap_core.resolve_output_dir(custom, '/default', seen, custom_dirs)
-        assert result == custom
-        assert os.path.isdir(custom)
-        assert custom in custom_dirs
+        assert os.path.realpath(result) == os.path.realpath(custom)
+        assert os.path.isdir(result)
 
-    def test_custom_dir_no_reload(self, tmp_path):
+    def test_custom_dir_no_reload(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(xtap_core, '_ALLOWED_ROOTS', (os.path.realpath(str(tmp_path)),))
         custom = str(tmp_path / 'custom')
         os.makedirs(custom)
         seen = set()
         custom_dirs = set()
         # First call adds to custom_dirs
-        xtap_core.resolve_output_dir(custom, '/default', seen, custom_dirs)
-        assert custom in custom_dirs
+        result = xtap_core.resolve_output_dir(custom, '/default', seen, custom_dirs)
+        assert result in custom_dirs
         # Second call — custom_dirs already has it, load_seen_ids not called again
         old_size = len(custom_dirs)
         xtap_core.resolve_output_dir(custom, '/default', seen, custom_dirs)
@@ -202,7 +203,8 @@ class TestResolveOutputDir:
         if os.path.isdir(expected):
             os.rmdir(expected)
 
-    def test_custom_dir_loads_seen_ids(self, tmp_path):
+    def test_custom_dir_loads_seen_ids(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(xtap_core, '_ALLOWED_ROOTS', (os.path.realpath(str(tmp_path)),))
         custom = str(tmp_path / 'custom')
         os.makedirs(custom)
         (tmp_path / 'custom' / 'tweets-2024-01-15.jsonl').write_text(
@@ -212,6 +214,46 @@ class TestResolveOutputDir:
         custom_dirs = set()
         xtap_core.resolve_output_dir(custom, '/default', seen, custom_dirs)
         assert '999' in seen
+
+
+# ---------------------------------------------------------------------------
+# validate_output_dir
+# ---------------------------------------------------------------------------
+
+
+class TestValidateOutputDir:
+
+    def test_path_under_home_allowed(self):
+        home = os.path.expanduser('~')
+        result = xtap_core.validate_output_dir(os.path.join(home, 'some', 'subdir'))
+        assert result.startswith(os.path.realpath(home))
+
+    def test_home_itself_allowed(self):
+        home = os.path.expanduser('~')
+        result = xtap_core.validate_output_dir(home)
+        assert result == os.path.realpath(home)
+
+    def test_traversal_outside_home_rejected(self):
+        with pytest.raises(ValueError, match='outside allowed directories'):
+            xtap_core.validate_output_dir('/etc/cron.d/evil')
+
+    def test_dot_dot_traversal_rejected(self):
+        home = os.path.expanduser('~')
+        with pytest.raises(ValueError, match='outside allowed directories'):
+            # Enough '..' to escape home
+            xtap_core.validate_output_dir(os.path.join(home, '..', '..', 'tmp', 'pwned'))
+
+    def test_absolute_path_outside_home_rejected(self):
+        with pytest.raises(ValueError, match='outside allowed directories'):
+            xtap_core.validate_output_dir('/tmp/pwned')
+
+    def test_resolve_output_dir_rejects_traversal(self):
+        with pytest.raises(ValueError, match='outside allowed directories'):
+            xtap_core.resolve_output_dir('/etc/evil', '/default', set(), set())
+
+    def test_default_output_dir_allowed(self):
+        result = xtap_core.validate_output_dir(xtap_core.DEFAULT_OUTPUT_DIR)
+        assert result == os.path.realpath(xtap_core.DEFAULT_OUTPUT_DIR)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_xtap_daemon.py
+++ b/tests/test_xtap_daemon.py
@@ -229,3 +229,13 @@ class TestAuthorizedRequest:
         assert resp.status == 200
         assert body['ok'] is True
         conn.close()
+
+    def test_dump_rejects_dotdot_filename(self, daemon_url):
+        """POST /dump with '..' filename should return 400."""
+        status, body = _post(
+            daemon_url, '/dump',
+            body={'filename': '..', 'content': 'x'},
+            token=TEST_TOKEN,
+        )
+        assert status == 400
+        assert 'Invalid dump filename' in body['error']

--- a/tests/test_xtap_daemon.py
+++ b/tests/test_xtap_daemon.py
@@ -196,16 +196,22 @@ class TestAuthorizedRequest:
         assert body['ok'] is True
         assert 'version' in body
 
-    def test_valid_post_succeeds(self, daemon_url, tmp_path):
+    def test_valid_post_succeeds(self, daemon_url):
         """An authorized POST /tweets with valid body should succeed."""
-        status, body = _post(
-            daemon_url, '/tweets',
-            body={'outputDir': str(tmp_path), 'tweets': [{'id': '1', 'text': 'hello'}]},
-            token=TEST_TOKEN,
-        )
-        assert status == 200
-        assert body['ok'] is True
-        assert body['count'] == 1
+        import tempfile
+        out_dir = tempfile.mkdtemp(dir=os.path.expanduser('~'), prefix='.xtap-test-')
+        try:
+            status, body = _post(
+                daemon_url, '/tweets',
+                body={'outputDir': out_dir, 'tweets': [{'id': '1', 'text': 'hello'}]},
+                token=TEST_TOKEN,
+            )
+            assert status == 200
+            assert body['ok'] is True
+            assert body['count'] == 1
+        finally:
+            import shutil
+            shutil.rmtree(out_dir, ignore_errors=True)
 
     def test_zero_content_length_post(self, daemon_url):
         """POST with Content-Length: 0 exercises _read_json returning {}."""


### PR DESCRIPTION
## Summary
- Add `validate_output_dir()` in `xtap_core.py` — resolves symlinks via `realpath()`, checks result is under user's home or `DEFAULT_OUTPUT_DIR`
- Integrate into `resolve_output_dir()` so all endpoints using it are protected (`/tweets`, `/log`, `/dump`, `/download-video`)
- Fix `/test-path` handler which bypassed `resolve_output_dir` — now also validated
- All traversal rejections return `400 Bad Request` with descriptive error
- `XTAP_OUTPUT_DIR` pointing outside home (e.g. `/data/xtap`) is allowed as a second root

Closes #11

## Test plan
- [x] Path under home allowed
- [x] Home directory itself allowed
- [x] `/etc/cron.d/evil` rejected
- [x] `../../tmp/pwned` traversal rejected
- [x] `/tmp/pwned` absolute path rejected
- [x] `resolve_output_dir` rejects traversal
- [x] `DEFAULT_OUTPUT_DIR` always allowed
- [x] All 50 existing tests still pass