### PR TITLE
fix: threading server and concurrent state safety

### DIFF
--- a/native-host/xtap_core.py
+++ b/native-host/xtap_core.py
@@ -120,10 +120,15 @@ def write_dump(filename, content, out_dir):
 def test_path(out_dir):
     """Test that we can write to the output directory. Raises on failure."""
     os.makedirs(out_dir, exist_ok=True)
-    test_file = os.path.join(out_dir, '.xtap-write-test')
-    with open(test_file, 'w') as f:
-        f.write('ok')
-    os.remove(test_file)
+    test_file = os.path.join(out_dir, f'.xtap-write-test-{threading.get_ident()}')
+    try:
+        with open(test_file, 'w') as f:
+            f.write('ok')
+    finally:
+        try:
+            os.remove(test_file)
+        except FileNotFoundError:
+            pass
 
 
 # --- Video download ---

--- a/native-host/xtap_core.py
+++ b/native-host/xtap_core.py
@@ -131,6 +131,7 @@ def test_path(out_dir):
 _ytdlp_path = None
 _ytdlp_checked = False
 _downloads = {}
+_downloads_lock = threading.Lock()
 
 
 def check_ytdlp():  # pragma: no cover
@@ -144,15 +145,16 @@ def check_ytdlp():  # pragma: no cover
 
 def get_download_status(download_id):
     """Return current state of a download."""
-    info = _downloads.get(download_id)
-    if not info:
-        return {'status': 'unknown'}
-    return {
-        'status': info['status'],
-        'progress': info.get('progress'),
-        'path': info.get('path'),
-        'error': info.get('error'),
-    }
+    with _downloads_lock:
+        info = _downloads.get(download_id)
+        if not info:
+            return {'status': 'unknown'}
+        return {
+            'status': info['status'],
+            'progress': info.get('progress'),
+            'path': info.get('path'),
+            'error': info.get('error'),
+        }
 
 
 def _date_prefix(post_date):
@@ -184,32 +186,37 @@ def start_download(download_id, tweet_url, direct_url, out_dir, post_date=''):  
     video_dir = os.path.join(out_dir, 'videos')
     os.makedirs(video_dir, exist_ok=True)
 
-    _downloads[download_id] = {
-        'status': 'downloading',
-        'progress': None,
-        'path': None,
-        'error': None,
-    }
+    with _downloads_lock:
+        _downloads[download_id] = {
+            'status': 'downloading',
+            'progress': None,
+            'path': None,
+            'error': None,
+        }
 
     def run():
         try:
             if check_ytdlp():
                 _download_with_ytdlp(download_id, tweet_url, video_dir, post_date)
             elif direct_url:
-                _downloads[download_id]['progress'] = 0
+                with _downloads_lock:
+                    _downloads[download_id]['progress'] = 0
                 # Extract tweet ID from URL
                 m = re.search(r'/status/(\d+)', tweet_url)
                 tweet_id = m.group(1) if m else download_id
                 path = download_direct(direct_url, tweet_id, video_dir, post_date)
-                _downloads[download_id]['progress'] = 100
-                _downloads[download_id]['status'] = 'done'
-                _downloads[download_id]['path'] = path
+                with _downloads_lock:
+                    _downloads[download_id].update(
+                        progress=100, status='done', path=path)
             else:
-                _downloads[download_id]['status'] = 'error'
-                _downloads[download_id]['error'] = 'yt-dlp not found and no direct URL available'
+                with _downloads_lock:
+                    _downloads[download_id].update(
+                        status='error',
+                        error='yt-dlp not found and no direct URL available')
         except Exception as e:
-            _downloads[download_id]['status'] = 'error'
-            _downloads[download_id]['error'] = str(e)
+            with _downloads_lock:
+                _downloads[download_id].update(
+                    status='error', error=str(e))
 
     t = threading.Thread(target=run, daemon=True)
     t.start()
@@ -251,7 +258,8 @@ def _download_with_ytdlp(download_id, tweet_url, video_dir, post_date=''):  # pr
         # Parse progress percentage
         m = progress_re.search(line)
         if m:
-            _downloads[download_id]['progress'] = float(m.group(1))
+            with _downloads_lock:
+                _downloads[download_id]['progress'] = float(m.group(1))
         # Capture output filename from [download] or [Merger] lines
         if 'Destination:' in line:
             final_path = line.split('Destination:', 1)[1].strip()
@@ -272,6 +280,6 @@ def _download_with_ytdlp(download_id, tweet_url, video_dir, post_date=''):  # pr
         dest_path = os.path.join(video_dir, os.path.basename(final_path))
         shutil.move(final_path, dest_path)
         final_path = dest_path
-    _downloads[download_id]['progress'] = 100
-    _downloads[download_id]['status'] = 'done'
-    _downloads[download_id]['path'] = final_path
+    with _downloads_lock:
+        _downloads[download_id].update(
+            progress=100, status='done', path=final_path)

--- a/native-host/xtap_daemon.py
+++ b/native-host/xtap_daemon.py
@@ -178,9 +178,9 @@ class DaemonHandler(BaseHTTPRequestHandler):
             msg_dir = body.get('outputDir', '').strip()
             with _state_lock:
                 out_dir = resolve_output_dir(msg_dir, DEFAULT_OUTPUT_DIR, _seen_ids, _custom_dirs)
-            filename = body.get('filename', 'dump.json')
-            content = body.get('content', '')
-            path = write_dump(filename, content, out_dir)
+                filename = body.get('filename', 'dump.json')
+                content = body.get('content', '')
+                path = write_dump(filename, content, out_dir)
             self._send_json({'ok': True, 'path': path})
         except ValueError as e:
             self._send_json({'ok': False, 'error': str(e)}, 400)

--- a/native-host/xtap_daemon.py
+++ b/native-host/xtap_daemon.py
@@ -9,7 +9,8 @@ import signal
 import sys
 import time
 import uuid
-from http.server import HTTPServer, BaseHTTPRequestHandler
+import threading
+from http.server import ThreadingHTTPServer, BaseHTTPRequestHandler
 
 from xtap_core import (DEFAULT_OUTPUT_DIR, load_seen_ids, resolve_output_dir,
                        validate_output_dir, write_tweets, write_log,
@@ -49,6 +50,7 @@ def load_token():
 _token = None
 _seen_ids = set()
 _custom_dirs = set()
+_state_lock = threading.Lock()
 
 
 class DaemonHandler(BaseHTTPRequestHandler):
@@ -143,9 +145,10 @@ class DaemonHandler(BaseHTTPRequestHandler):
     def _handle_tweets(self, body):
         try:
             msg_dir = body.get('outputDir', '').strip()
-            out_dir = resolve_output_dir(msg_dir, DEFAULT_OUTPUT_DIR, _seen_ids, _custom_dirs)
-            tweets = body.get('tweets', [])
-            count, dupes = write_tweets(tweets, out_dir, _seen_ids)
+            with _state_lock:
+                out_dir = resolve_output_dir(msg_dir, DEFAULT_OUTPUT_DIR, _seen_ids, _custom_dirs)
+                tweets = body.get('tweets', [])
+                count, dupes = write_tweets(tweets, out_dir, _seen_ids)
             log_debug(f'  Tweets: {count} written, {dupes} dupes -> {out_dir}')
             self._send_json({'ok': True, 'count': count, 'dupes': dupes})
         except ValueError as e:
@@ -158,7 +161,8 @@ class DaemonHandler(BaseHTTPRequestHandler):
     def _handle_log(self, body):
         try:
             msg_dir = body.get('outputDir', '').strip()
-            out_dir = resolve_output_dir(msg_dir, DEFAULT_OUTPUT_DIR, _seen_ids, _custom_dirs)
+            with _state_lock:
+                out_dir = resolve_output_dir(msg_dir, DEFAULT_OUTPUT_DIR, _seen_ids, _custom_dirs)
             lines = body.get('lines', [])
             logged = write_log(lines, out_dir)
             self._send_json({'ok': True, 'logged': logged})
@@ -172,7 +176,8 @@ class DaemonHandler(BaseHTTPRequestHandler):
     def _handle_dump(self, body):
         try:
             msg_dir = body.get('outputDir', '').strip()
-            out_dir = resolve_output_dir(msg_dir, DEFAULT_OUTPUT_DIR, _seen_ids, _custom_dirs)
+            with _state_lock:
+                out_dir = resolve_output_dir(msg_dir, DEFAULT_OUTPUT_DIR, _seen_ids, _custom_dirs)
             filename = body.get('filename', 'dump.json')
             content = body.get('content', '')
             path = write_dump(filename, content, out_dir)
@@ -210,7 +215,8 @@ class DaemonHandler(BaseHTTPRequestHandler):
             direct_url = body.get('directUrl', '')
             post_date = body.get('postDate', '')
             msg_dir = body.get('outputDir', '').strip()
-            out_dir = resolve_output_dir(msg_dir, DEFAULT_OUTPUT_DIR, _seen_ids, _custom_dirs)
+            with _state_lock:
+                out_dir = resolve_output_dir(msg_dir, DEFAULT_OUTPUT_DIR, _seen_ids, _custom_dirs)
             download_id = str(uuid.uuid4())
             start_download(download_id, tweet_url, direct_url, out_dir, post_date)
             log_debug(f'  Download started: {download_id} -> {tweet_url}')
@@ -281,7 +287,7 @@ def main():
     log_info(f'  Seen IDs:   {len(_seen_ids)} loaded')
 
     try:
-        server = HTTPServer((BIND_HOST, BIND_PORT), DaemonHandler)
+        server = ThreadingHTTPServer((BIND_HOST, BIND_PORT), DaemonHandler)
     except OSError as e:
         log_info(f'FATAL: Cannot bind to {BIND_HOST}:{BIND_PORT} — {e}')
         log_info(f'  Is another instance already running?')

--- a/tests/test_xtap_core.py
+++ b/tests/test_xtap_core.py
@@ -340,7 +340,8 @@ class TestTestPath:
 
     def test_no_leftover_file(self, tmp_path):
         xtap_core.test_path(str(tmp_path))
-        assert not (tmp_path / '.xtap-write-test').exists()
+        leftover = [f for f in os.listdir(str(tmp_path)) if f.startswith('.xtap-write-test')]
+        assert leftover == [], f'Sentinel not cleaned up: {leftover}'
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_xtap_core.py
+++ b/tests/test_xtap_core.py
@@ -343,6 +343,18 @@ class TestTestPath:
         leftover = [f for f in os.listdir(str(tmp_path)) if f.startswith('.xtap-write-test')]
         assert leftover == [], f'Sentinel not cleaned up: {leftover}'
 
+    def test_cleanup_tolerates_missing_sentinel(self, tmp_path, monkeypatch):
+        """test_path should not raise if the sentinel is already removed (race)."""
+        original_remove = os.remove
+
+        def remove_twice(path):
+            original_remove(path)
+            # Simulate a concurrent removal — file is already gone
+            original_remove(path)
+
+        monkeypatch.setattr(os, 'remove', remove_twice)
+        xtap_core.test_path(str(tmp_path))  # should not raise
+
 
 # ---------------------------------------------------------------------------
 # get_download_status

--- a/tests/test_xtap_daemon.py
+++ b/tests/test_xtap_daemon.py
@@ -10,6 +10,7 @@ import urllib.request
 import urllib.error
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'native-host'))
+import xtap_core
 import xtap_daemon
 
 
@@ -32,8 +33,8 @@ def _set_module_token():
 @pytest.fixture()
 def daemon_url():
     """Start DaemonHandler on an ephemeral port and return its base URL."""
-    from http.server import HTTPServer
-    server = HTTPServer(('127.0.0.1', 0), xtap_daemon.DaemonHandler)
+    from http.server import ThreadingHTTPServer
+    server = ThreadingHTTPServer(('127.0.0.1', 0), xtap_daemon.DaemonHandler)
     port = server.server_address[1]
     t = threading.Thread(target=server.serve_forever, daemon=True)
     t.start()
@@ -239,3 +240,110 @@ class TestAuthorizedRequest:
         )
         assert status == 400
         assert 'Invalid dump filename' in body['error']
+
+
+# ---------------------------------------------------------------------------
+# Tests — Concurrency (issue #8)
+# ---------------------------------------------------------------------------
+
+class TestConcurrency:
+
+    def test_status_responsive_during_slow_tweets(self, daemon_url):
+        """GET /status should respond promptly while a slow /tweets is in progress."""
+        import shutil
+        import tempfile
+        import time
+        from unittest.mock import patch
+        import concurrent.futures
+
+        out_dir = tempfile.mkdtemp(dir=os.path.expanduser('~'), prefix='.xtap-test-')
+
+        slow_entered = threading.Event()
+        original_write_tweets = xtap_daemon.write_tweets
+
+        def slow_write_tweets(tweets, out_dir, seen_ids):
+            slow_entered.set()
+            time.sleep(1.0)
+            return original_write_tweets(tweets, out_dir, seen_ids)
+
+        try:
+            with patch.object(xtap_daemon, 'write_tweets', side_effect=slow_write_tweets):
+                with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+                    # Fire off the slow /tweets request
+                    tweets_future = pool.submit(
+                        _post, daemon_url, '/tweets',
+                        {'outputDir': out_dir, 'tweets': [{'id': '1', 'text': 'hi'}]},
+                        TEST_TOKEN,
+                    )
+
+                    # Wait until the slow handler has started
+                    assert slow_entered.wait(timeout=5), 'slow write_tweets never entered'
+
+                    # Now /status should respond quickly
+                    t0 = time.monotonic()
+                    req = urllib.request.Request(f'{daemon_url}/status')
+                    with urllib.request.urlopen(req, timeout=2) as resp:
+                        status_body = json.loads(resp.read())
+                    elapsed = time.monotonic() - t0
+
+                    assert status_body['ok'] is True
+                    assert elapsed < 0.5, f'/status took {elapsed:.2f}s — blocked by slow /tweets'
+
+                    # Let the tweets request finish
+                    tweets_status, tweets_body = tweets_future.result(timeout=5)
+                    assert tweets_status == 200
+                    assert tweets_body['ok'] is True
+        finally:
+            shutil.rmtree(out_dir, ignore_errors=True)
+
+    def test_download_status_coherent(self):
+        """get_download_status never returns partial state (e.g. status=done with path=None)."""
+        import time
+
+        download_id = 'coherence-test'
+        errors = []
+        stop = threading.Event()
+
+        # Seed initial state
+        with xtap_core._downloads_lock:
+            xtap_core._downloads[download_id] = {
+                'status': 'downloading',
+                'progress': 0,
+                'path': None,
+                'error': None,
+            }
+
+        def reader():
+            while not stop.is_set():
+                s = xtap_core.get_download_status(download_id)
+                if s['status'] == 'done' and s['path'] is None:
+                    errors.append(f'Incoherent: status=done but path=None')
+                if s['status'] == 'error' and s['error'] is None:
+                    errors.append(f'Incoherent: status=error but error=None')
+
+        def writer():
+            for i in range(200):
+                with xtap_core._downloads_lock:
+                    xtap_core._downloads[download_id].update(
+                        progress=i, status='done', path='/tmp/video.mp4')
+                with xtap_core._downloads_lock:
+                    xtap_core._downloads[download_id].update(
+                        progress=0, status='downloading', path=None, error=None)
+            stop.set()
+
+        readers = [threading.Thread(target=reader) for _ in range(4)]
+        for r in readers:
+            r.start()
+        writer_t = threading.Thread(target=writer)
+        writer_t.start()
+
+        writer_t.join(timeout=5)
+        stop.set()
+        for r in readers:
+            r.join(timeout=2)
+
+        # Clean up
+        with xtap_core._downloads_lock:
+            del xtap_core._downloads[download_id]
+
+        assert not errors, f'Found incoherent reads: {errors[:5]}'


### PR DESCRIPTION
## Summary
- Switch `HTTPServer` → `ThreadingHTTPServer` so status polling (`/status`, `/download-status`) stays responsive during slow `/tweets` or `/dump` writes
- Add `_state_lock` in `xtap_daemon.py` to protect `_seen_ids` and `_custom_dirs` under concurrent request handling
- Add `_downloads_lock` in `xtap_core.py` to make multi-field download state transitions atomic (prevents partial reads like `status=done` with `path=None`)

## Test plan
- [x] `test_status_responsive_during_slow_tweets` — mocks a 1s slow write, verifies `/status` responds in <0.5s concurrently
- [x] `test_download_status_coherent` — 4 reader threads + 1 writer thread verify no partial state is ever observed
- [x] All 68 existing tests pass

Closes #8