### PR TITLE
fix: durable staging of GRAPHQL_RESPONSE payloads

### DIFF
--- a/background.js
+++ b/background.js
@@ -23,6 +23,7 @@ const isDevMode = !chrome.runtime.getManifest().update_url;
 const hasSessionStorage = !!chrome.storage.session;
 const traceStorage = chrome.storage.session || chrome.storage.local;
 let stageSeq = 0;
+let _saveChain = Promise.resolve();
 let readyResolve;
 const ready = new Promise(r => { readyResolve = r; });
 
@@ -112,7 +113,8 @@ async function recoverStagedPayloads() {
     }
     // Persist buffer before clearing WAL entry — if SW dies mid-recovery,
     // already-cleared entries must have their tweets in durable storage.
-    if (produced) await saveState();
+    // If saveState fails, keep the WAL entry for retry on next startup.
+    if (produced && !(await saveState())) continue;
     await clearStagedPayload(key);
   }
 
@@ -122,23 +124,34 @@ async function recoverStagedPayloads() {
   }
 }
 
-async function saveState() {
-  // seenIds and tweetBuffer are separate writes so a quota failure on the
-  // (potentially large) buffer doesn't take down dedup state with it.
+// Serialized via _saveChain so concurrent callers can't interleave writes
+// (back-to-back handlers would otherwise race, and an earlier snapshot could
+// land after a later one, rolling back buffered tweets).  Returns true on
+// success, false on storage error — callers gate WAL clears on this.
+function saveState() {
+  const p = _saveChain.then(() => _saveStateImpl());
+  _saveChain = p.catch(() => {});
+  return p;
+}
+
+async function _saveStateImpl() {
+  // seenIds and tweetBuffer are coupled in one write so a quota failure
+  // loses both rather than persisting seenIds without the buffer (which
+  // would create ghost-dedup entries that permanently block those tweets).
   const seenArr = [...seenIds].slice(-MAX_SEEN_IDS);
-  const bufferWrite = seenIdsStorage().set({ tweetBuffer: buffer }).catch(e =>
-    console.warn('[xTap] Failed to persist buffer:', e.message));
-  if (isDevMode && hasSessionStorage) {
-    await Promise.all([
-      chrome.storage.session.set({ seenIds: seenArr }),
-      bufferWrite,
-      chrome.storage.local.set({ allTimeCount, captureEnabled }),
-    ]);
-  } else {
-    await Promise.all([
-      chrome.storage.local.set({ seenIds: seenArr, allTimeCount, captureEnabled }),
-      bufferWrite,
-    ]);
+  try {
+    if (isDevMode && hasSessionStorage) {
+      await Promise.all([
+        chrome.storage.session.set({ seenIds: seenArr, tweetBuffer: buffer }),
+        chrome.storage.local.set({ allTimeCount, captureEnabled }),
+      ]);
+    } else {
+      await chrome.storage.local.set({ seenIds: seenArr, tweetBuffer: buffer, allTimeCount, captureEnabled });
+    }
+    return true;
+  } catch (e) {
+    console.warn('[xTap] Failed to persist state:', e.message);
+    return false;
   }
 }
 
@@ -594,9 +607,12 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
           if (missingText > 0) warn += ` | ${missingText} missing text`;
           console.log(`[xTap] ${msg.endpoint}: ${tweets.length} tweets${warn}`);
           enqueueTweets(tweets, msg.endpoint);
-          await saveState();
+          // Only clear WAL after state is durably persisted — if saveState
+          // fails, the WAL entry stays for recovery on next startup.
+          if (await saveState()) await clearStagedPayload(stageKey);
+        } else {
+          await clearStagedPayload(stageKey);
         }
-        await clearStagedPayload(stageKey);
         // Flush after WAL commit so buffer.splice in flush() can't race with
         // the persist-then-clear sequence above.
         if (buffer.length >= BATCH_SIZE) flush();

--- a/background.js
+++ b/background.js
@@ -44,6 +44,10 @@ function seenIdsStorage() {
   return (isDevMode && hasSessionStorage) ? chrome.storage.session : chrome.storage.local;
 }
 
+// Staging uses session whenever available (ephemeral — cleared on browser restart).
+// seenIdsStorage() uses session only in dev mode. In production, seenIds goes to
+// local for persistence while WAL entries stay in session (they only need to survive
+// SW suspension, not browser restart). Firefox without session falls back to local.
 function stagingStorage() {
   return hasSessionStorage ? chrome.storage.session : chrome.storage.local;
 }
@@ -55,6 +59,7 @@ async function stagePayload(endpoint, data) {
     return key;
   } catch (e) {
     console.warn('[xTap] Failed to stage payload (quota?):', e.message);
+    emitTraceEvent({ timestamp: Date.now(), endpoint, tweetId: null, status: 'STAGE_FAILED', reason: e.message });
     return null;
   }
 }
@@ -63,7 +68,9 @@ async function clearStagedPayload(key) {
   if (!key) return;
   try {
     await stagingStorage().remove(key);
-  } catch {}
+  } catch (e) {
+    console.warn('[xTap] Failed to clear staged payload:', e.message);
+  }
 }
 
 async function recoverStagedPayloads() {
@@ -74,7 +81,11 @@ async function recoverStagedPayloads() {
     console.warn('[xTap] Failed to read staging storage for recovery:', e.message);
     return;
   }
-  const keys = Object.keys(store).filter(k => k.startsWith('stg_')).sort();
+  const keys = Object.keys(store).filter(k => k.startsWith('stg_')).sort((a, b) => {
+    const [, tsA, seqA] = a.split('_');
+    const [, tsB, seqB] = b.split('_');
+    return (tsA - tsB) || (seqA - seqB);
+  });
   if (keys.length === 0) return;
 
   const now = Date.now();
@@ -83,6 +94,7 @@ async function recoverStagedPayloads() {
 
   for (const key of keys) {
     const entry = store[key];
+    let produced = false;
     try {
       if (!entry || !entry.data || (entry.stagedAt && now - entry.stagedAt > TTL)) {
         await clearStagedPayload(key);
@@ -93,29 +105,40 @@ async function recoverStagedPayloads() {
       if (tweets.length > 0) {
         enqueueTweets(tweets, entry.endpoint);
         recoveredCount += tweets.length;
+        produced = true;
       }
     } catch (e) {
       console.warn(`[xTap] Recovery parse error for ${key}:`, e.message);
     }
+    // Persist buffer before clearing WAL entry — if SW dies mid-recovery,
+    // already-cleared entries must have their tweets in durable storage.
+    if (produced) await saveState();
     await clearStagedPayload(key);
   }
 
   if (recoveredCount > 0) {
-    await saveState();
     emitTraceEvent({ timestamp: Date.now(), endpoint: 'recovery', tweetId: null, status: 'RECOVERY_COMPLETE', reason: `recovered ${recoveredCount} tweets from ${keys.length} staged payloads` });
     console.log(`[xTap] Recovery: ${recoveredCount} tweets from ${keys.length} staged payloads`);
   }
 }
 
 async function saveState() {
-  const seenData = { seenIds: [...seenIds].slice(-MAX_SEEN_IDS), tweetBuffer: buffer };
+  // seenIds and tweetBuffer are separate writes so a quota failure on the
+  // (potentially large) buffer doesn't take down dedup state with it.
+  const seenArr = [...seenIds].slice(-MAX_SEEN_IDS);
+  const bufferWrite = seenIdsStorage().set({ tweetBuffer: buffer }).catch(e =>
+    console.warn('[xTap] Failed to persist buffer:', e.message));
   if (isDevMode && hasSessionStorage) {
     await Promise.all([
-      chrome.storage.session.set(seenData),
+      chrome.storage.session.set({ seenIds: seenArr }),
+      bufferWrite,
       chrome.storage.local.set({ allTimeCount, captureEnabled }),
     ]);
   } else {
-    await chrome.storage.local.set({ ...seenData, allTimeCount, captureEnabled });
+    await Promise.all([
+      chrome.storage.local.set({ seenIds: seenArr, allTimeCount, captureEnabled }),
+      bufferWrite,
+    ]);
   }
 }
 
@@ -456,8 +479,6 @@ function enqueueTweets(tweets, endpoint = 'unknown') {
     console.warn(`[xTap] Buffer overflow: dropped ${overflow} oldest tweets (cap: ${MAX_BUFFER_SIZE})`);
     emitTraceEvent({ timestamp: Date.now(), endpoint, tweetId: null, status: 'BUFFER_OVERFLOW', reason: `dropped ${overflow}` });
   }
-
-  if (buffer.length >= BATCH_SIZE) flush();
 }
 
 // --- Badge ---
@@ -554,13 +575,14 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
   if (msg.type === 'GRAPHQL_RESPONSE') {
     if (IGNORED_ENDPOINTS.has(msg.endpoint)) return;
     (async () => {
-      const stageKey = await stagePayload(msg.endpoint, msg.data);
       await ready;
       verboseLog(msg.endpoint, msg.data);
-      if (!captureEnabled) {
-        await clearStagedPayload(stageKey);
-        return;
-      }
+      if (!captureEnabled) return;
+      // Stage after ready + captureEnabled so we never WAL payloads that
+      // arrived while capture was off, and recovery can replay unconditionally.
+      // Staging after ready also means recovery completes before any handler
+      // can stage — no concurrent-mutation race.
+      const stageKey = await stagePayload(msg.endpoint, msg.data);
       try {
         const tweets = extractTweets(msg.endpoint, msg.data);
         for (const t of tweets) t.source_endpoint = msg.endpoint;
@@ -575,6 +597,9 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
           await saveState();
         }
         await clearStagedPayload(stageKey);
+        // Flush after WAL commit so buffer.splice in flush() can't race with
+        // the persist-then-clear sequence above.
+        if (buffer.length >= BATCH_SIZE) flush();
       } catch (e) {
         console.error(`[xTap] Parse error for ${msg.endpoint}:`, e, '| data keys:', Object.keys(msg.data || {}).join(', '));
         emitTraceEvent({ timestamp: Date.now(), endpoint: msg.endpoint, tweetId: null, status: 'PARSER_ERROR', reason: e.message });

--- a/background.js
+++ b/background.js
@@ -416,14 +416,14 @@ async function flush() {
       if (!resp || !resp.ok) {
         console.error('[xTap] Host rejected tweets:', resp?.error || 'no response');
         buffer.unshift(...batch);
-        saveState();
+        await saveState();
       } else {
-        saveState();
+        await saveState();
       }
     } catch (e) {
       console.error('[xTap] Send failed, buffering tweets back:', e);
       buffer.unshift(...batch);
-      saveState();
+      await saveState();
     }
   }
 

--- a/background.js
+++ b/background.js
@@ -7,6 +7,7 @@ const BATCH_SIZE = 50;
 const FLUSH_INTERVAL_MS = 30_000;
 const MAX_SEEN_IDS = 50_000;
 const HTTP_TIMEOUT_MS = 10_000;
+const MAX_BUFFER_SIZE = 2000;
 
 let captureEnabled = true;
 let buffer = [];
@@ -21,6 +22,7 @@ let logBuffer = [];
 const isDevMode = !chrome.runtime.getManifest().update_url;
 const hasSessionStorage = !!chrome.storage.session;
 const traceStorage = chrome.storage.session || chrome.storage.local;
+let stageSeq = 0;
 let readyResolve;
 const ready = new Promise(r => { readyResolve = r; });
 
@@ -42,8 +44,71 @@ function seenIdsStorage() {
   return (isDevMode && hasSessionStorage) ? chrome.storage.session : chrome.storage.local;
 }
 
+function stagingStorage() {
+  return hasSessionStorage ? chrome.storage.session : chrome.storage.local;
+}
+
+async function stagePayload(endpoint, data) {
+  const key = `stg_${Date.now()}_${stageSeq++}`;
+  try {
+    await stagingStorage().set({ [key]: { endpoint, data, stagedAt: Date.now() } });
+    return key;
+  } catch (e) {
+    console.warn('[xTap] Failed to stage payload (quota?):', e.message);
+    return null;
+  }
+}
+
+async function clearStagedPayload(key) {
+  if (!key) return;
+  try {
+    await stagingStorage().remove(key);
+  } catch {}
+}
+
+async function recoverStagedPayloads() {
+  let store;
+  try {
+    store = await stagingStorage().get(null);
+  } catch (e) {
+    console.warn('[xTap] Failed to read staging storage for recovery:', e.message);
+    return;
+  }
+  const keys = Object.keys(store).filter(k => k.startsWith('stg_')).sort();
+  if (keys.length === 0) return;
+
+  const now = Date.now();
+  const TTL = 24 * 60 * 60 * 1000;
+  let recoveredCount = 0;
+
+  for (const key of keys) {
+    const entry = store[key];
+    try {
+      if (!entry || !entry.data || (entry.stagedAt && now - entry.stagedAt > TTL)) {
+        await clearStagedPayload(key);
+        continue;
+      }
+      const tweets = extractTweets(entry.endpoint, entry.data);
+      for (const t of tweets) t.source_endpoint = entry.endpoint;
+      if (tweets.length > 0) {
+        enqueueTweets(tweets, entry.endpoint);
+        recoveredCount += tweets.length;
+      }
+    } catch (e) {
+      console.warn(`[xTap] Recovery parse error for ${key}:`, e.message);
+    }
+    await clearStagedPayload(key);
+  }
+
+  if (recoveredCount > 0) {
+    await saveState();
+    emitTraceEvent({ timestamp: Date.now(), endpoint: 'recovery', tweetId: null, status: 'RECOVERY_COMPLETE', reason: `recovered ${recoveredCount} tweets from ${keys.length} staged payloads` });
+    console.log(`[xTap] Recovery: ${recoveredCount} tweets from ${keys.length} staged payloads`);
+  }
+}
+
 async function saveState() {
-  const seenData = { seenIds: [...seenIds].slice(-MAX_SEEN_IDS) };
+  const seenData = { seenIds: [...seenIds].slice(-MAX_SEEN_IDS), tweetBuffer: buffer };
   if (isDevMode && hasSessionStorage) {
     await Promise.all([
       chrome.storage.session.set(seenData),
@@ -56,10 +121,11 @@ async function saveState() {
 
 async function restoreState() {
   const [seenStored, stored] = await Promise.all([
-    seenIdsStorage().get(['seenIds']),
+    seenIdsStorage().get(['seenIds', 'tweetBuffer']),
     chrome.storage.local.get(['allTimeCount', 'captureEnabled', 'outputDir', 'debugLogging', 'verboseLogging']),
   ]);
   if (seenStored.seenIds) seenIds = new Set(seenStored.seenIds.filter(Boolean));
+  if (Array.isArray(seenStored.tweetBuffer)) buffer = seenStored.tweetBuffer;
   if (typeof stored.allTimeCount === 'number') allTimeCount = stored.allTimeCount;
   if (typeof stored.captureEnabled === 'boolean') captureEnabled = stored.captureEnabled;
   if (typeof stored.outputDir === 'string') outputDir = stored.outputDir;
@@ -314,12 +380,14 @@ async function flush() {
       if (!resp || !resp.ok) {
         console.error('[xTap] Host rejected tweets:', resp?.error || 'no response');
         buffer.unshift(...batch);
+        saveState();
       } else {
         saveState();
       }
     } catch (e) {
       console.error('[xTap] Send failed, buffering tweets back:', e);
       buffer.unshift(...batch);
+      saveState();
     }
   }
 
@@ -381,6 +449,13 @@ function enqueueTweets(tweets, endpoint = 'unknown') {
   sessionCount += newCount;
   allTimeCount += newCount;
   updateBadge();
+
+  if (buffer.length > MAX_BUFFER_SIZE) {
+    const overflow = buffer.length - MAX_BUFFER_SIZE;
+    buffer.splice(0, overflow);
+    console.warn(`[xTap] Buffer overflow: dropped ${overflow} oldest tweets (cap: ${MAX_BUFFER_SIZE})`);
+    emitTraceEvent({ timestamp: Date.now(), endpoint, tweetId: null, status: 'BUFFER_OVERFLOW', reason: `dropped ${overflow}` });
+  }
 
   if (buffer.length >= BATCH_SIZE) flush();
 }
@@ -477,12 +552,13 @@ const IGNORED_ENDPOINTS = new Set([
 
 chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
   if (msg.type === 'GRAPHQL_RESPONSE') {
+    if (IGNORED_ENDPOINTS.has(msg.endpoint)) return;
     (async () => {
+      const stageKey = await stagePayload(msg.endpoint, msg.data);
       await ready;
       verboseLog(msg.endpoint, msg.data);
-      if (!captureEnabled) return;
-      if (IGNORED_ENDPOINTS.has(msg.endpoint)) {
-        if (verboseLogging) console.log(`[xTap:verbose] ${msg.endpoint} (ignored)`);
+      if (!captureEnabled) {
+        await clearStagedPayload(stageKey);
         return;
       }
       try {
@@ -496,10 +572,13 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
           if (missingText > 0) warn += ` | ${missingText} missing text`;
           console.log(`[xTap] ${msg.endpoint}: ${tweets.length} tweets${warn}`);
           enqueueTweets(tweets, msg.endpoint);
+          await saveState();
         }
+        await clearStagedPayload(stageKey);
       } catch (e) {
         console.error(`[xTap] Parse error for ${msg.endpoint}:`, e, '| data keys:', Object.keys(msg.data || {}).join(', '));
         emitTraceEvent({ timestamp: Date.now(), endpoint: msg.endpoint, tweetId: null, status: 'PARSER_ERROR', reason: e.message });
+        await clearStagedPayload(stageKey);
       }
     })();
     return;
@@ -667,6 +746,7 @@ if (typeof chrome.storage.session?.setAccessLevel === 'function') {
 restoreState().catch((e) => {
   console.error('[xTap] Failed to restore state:', e);
 }).then(async () => {
+  await recoverStagedPayloads();
   readyResolve();
   updateBadge();
   await initTransport();

--- a/tests/staging-wal.test.mjs
+++ b/tests/staging-wal.test.mjs
@@ -1,0 +1,281 @@
+/**
+ * Tests for WAL staging, buffer persistence, and buffer overflow (issue #9).
+ * Run with: node --test tests/staging-wal.test.mjs
+ *
+ * Evaluates background.js in a vm context with mocked chrome APIs
+ * to test the actual staging, recovery, and buffer logic.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import vm from 'node:vm';
+import { dedupTweet } from '../lib/dedup.js';
+
+const bgSource = readFileSync(new URL('../background.js', import.meta.url), 'utf8');
+
+// Strip ESM imports and init block; expose internals via var (added to sandbox)
+const testSource = bgSource
+  .replace(/^import\b.*$/gm, '')
+  .replace(/\/\/ --- Init ---[\s\S]*$/,
+    `var _internals = {
+      stagePayload, clearStagedPayload, recoverStagedPayloads,
+      saveState, restoreState, enqueueTweets,
+      stagingStorage, seenIdsStorage,
+      get buffer() { return buffer; },
+      set buffer(v) { buffer = v; },
+      get seenIds() { return seenIds; },
+      set seenIds(v) { seenIds = v; },
+      get traceEvents() { return traceEvents; },
+      MAX_BUFFER_SIZE,
+    };`
+  );
+
+function createMockStorage(opts = {}) {
+  let data = {};
+  return {
+    get(keys) {
+      if (keys === null) return Promise.resolve({ ...data });
+      const result = {};
+      const list = Array.isArray(keys) ? keys : [keys];
+      for (const k of list) if (k in data) result[k] = data[k];
+      return Promise.resolve(result);
+    },
+    set(items) {
+      if (opts.throwOnSet) return Promise.reject(new Error('QuotaExceededError'));
+      Object.assign(data, items);
+      return Promise.resolve();
+    },
+    remove(keys) {
+      const list = Array.isArray(keys) ? keys : [keys];
+      for (const k of list) delete data[k];
+      return Promise.resolve();
+    },
+    setAccessLevel() { return Promise.resolve(); },
+  };
+}
+
+/**
+ * Create a fresh background.js environment with mocked chrome APIs.
+ * Returns the exposed internals (with live getters/setters) plus storage mocks.
+ */
+function setup(opts = {}) {
+  const sessionStore = createMockStorage(opts.sessionOpts);
+  const localStore = createMockStorage(opts.localOpts);
+
+  const sandbox = {
+    console: { log() {}, warn() {}, error() {} },
+    setTimeout: globalThis.setTimeout,
+    clearTimeout: globalThis.clearTimeout,
+    fetch: async () => ({ json: async () => ({}) }),
+    extractTweets: opts.extractTweets || (() => []),
+    dedupTweet,
+    chrome: {
+      runtime: {
+        getManifest: () => ({}), // no update_url → isDevMode = true
+        connectNative() { throw new Error('not available'); },
+        onMessage: { addListener() {} },
+        lastError: null,
+      },
+      storage: {
+        session: sessionStore,
+        local: localStore,
+      },
+      action: {
+        setBadgeText() {},
+        setBadgeBackgroundColor() {},
+      },
+    },
+  };
+
+  vm.runInNewContext(testSource, sandbox);
+
+  // Return internals directly (not spread) to preserve getters/setters
+  const env = sandbox._internals;
+  env.sessionStore = sessionStore;
+  env.localStore = localStore;
+  return env;
+}
+
+// ---------------------------------------------------------------------------
+// stagePayload + clearStagedPayload
+// ---------------------------------------------------------------------------
+
+describe('stagePayload + clearStagedPayload', () => {
+  it('round-trip: stage writes key, clear removes it', async () => {
+    const env = setup();
+    const key = await env.stagePayload('HomeTimeline', { foo: 1 });
+    assert.ok(key);
+    assert.ok(key.startsWith('stg_'));
+
+    const stored = await env.stagingStorage().get(null);
+    assert.ok(stored[key]);
+    assert.equal(stored[key].endpoint, 'HomeTimeline');
+
+    await env.clearStagedPayload(key);
+    const after = await env.stagingStorage().get(null);
+    assert.equal(after[key], undefined);
+  });
+
+  it('clear(null) is a no-op', async () => {
+    const env = setup();
+    await env.clearStagedPayload(null); // must not throw
+  });
+
+  it('returns null on quota error', async () => {
+    const env = setup({ sessionOpts: { throwOnSet: true } });
+    const key = await env.stagePayload('HomeTimeline', { foo: 1 });
+    assert.equal(key, null);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// recoverStagedPayloads
+// ---------------------------------------------------------------------------
+
+describe('recoverStagedPayloads', () => {
+  it('processes staged payloads and enqueues tweets', async () => {
+    const tweets = [
+      { id: '1', text: 'tweet 1' },
+      { id: '2', text: 'tweet 2' },
+      { id: '3', text: 'tweet 3' },
+    ];
+    const env = setup({
+      extractTweets: (_ep, data) => data?.tweets || [],
+    });
+
+    await env.stagePayload('HomeTimeline', { tweets: [tweets[0]] });
+    await env.stagePayload('UserTweets', { tweets: [tweets[1]] });
+    await env.stagePayload('TweetDetail', { tweets: [tweets[2]] });
+
+    await env.recoverStagedPayloads();
+
+    assert.equal(env.buffer.length, 3);
+    assert.equal(env.buffer[0].id, '1');
+    assert.equal(env.buffer[1].id, '2');
+    assert.equal(env.buffer[2].id, '3');
+
+    // All staging keys should be cleared
+    const stored = await env.stagingStorage().get(null);
+    const stgKeys = Object.keys(stored).filter(k => k.startsWith('stg_'));
+    assert.equal(stgKeys.length, 0);
+  });
+
+  it('dedup: skips tweets already in seenIds', async () => {
+    const env = setup({
+      extractTweets: (_ep, data) => data?.tweets || [],
+    });
+
+    env.seenIds = new Set(['1']);
+
+    await env.stagePayload('HomeTimeline', {
+      tweets: [{ id: '1', text: 'dupe' }, { id: '2', text: 'new' }],
+    });
+
+    await env.recoverStagedPayloads();
+
+    assert.equal(env.buffer.length, 1);
+    assert.equal(env.buffer[0].id, '2');
+  });
+
+  it('discards entries older than 24h', async () => {
+    const env = setup({
+      extractTweets: (_ep, data) => data?.tweets || [],
+    });
+
+    const oldKey = 'stg_1000_0';
+    await env.stagingStorage().set({
+      [oldKey]: {
+        endpoint: 'HomeTimeline',
+        data: { tweets: [{ id: '1', text: 'old' }] },
+        stagedAt: Date.now() - 25 * 60 * 60 * 1000,
+      },
+    });
+
+    await env.recoverStagedPayloads();
+
+    assert.equal(env.buffer.length, 0);
+    const stored = await env.stagingStorage().get(null);
+    assert.equal(stored[oldKey], undefined);
+  });
+
+  it('clears key even on parse error', async () => {
+    const env = setup({
+      extractTweets: () => { throw new Error('parse fail'); },
+    });
+
+    const key = await env.stagePayload('HomeTimeline', { foo: 'bad' });
+    await env.recoverStagedPayloads();
+
+    const stored = await env.stagingStorage().get(null);
+    assert.equal(stored[key], undefined);
+    assert.equal(env.buffer.length, 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// saveState / restoreState buffer persistence
+// ---------------------------------------------------------------------------
+
+describe('saveState / restoreState buffer persistence', () => {
+  it('round-trip: saves and restores buffer + seenIds', async () => {
+    const env = setup();
+
+    env.buffer = [{ id: '1', text: 'buffered' }, { id: '2', text: 'also buffered' }];
+    env.seenIds = new Set(['1', '2', '3']);
+
+    await env.saveState();
+
+    env.buffer = [];
+    env.seenIds = new Set();
+
+    await env.restoreState();
+
+    assert.equal(env.buffer.length, 2);
+    assert.equal(env.buffer[0].id, '1');
+    assert.equal(env.buffer[1].id, '2');
+    assert.ok(env.seenIds.has('1'));
+    assert.ok(env.seenIds.has('2'));
+    assert.ok(env.seenIds.has('3'));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Buffer overflow
+// ---------------------------------------------------------------------------
+
+describe('buffer overflow', () => {
+  it('drops oldest tweets when over MAX_BUFFER_SIZE', () => {
+    const env = setup();
+
+    // Pre-fill buffer to MAX_BUFFER_SIZE - 1
+    env.buffer = Array.from({ length: env.MAX_BUFFER_SIZE - 1 }, (_, i) => ({
+      id: `pre${i}`, text: `pre ${i}`,
+    }));
+
+    // Enqueue 2 more → total MAX_BUFFER_SIZE + 1 → overflow drops 1 oldest
+    env.enqueueTweets([
+      { id: 'new1', text: 'new 1' },
+      { id: 'new2', text: 'new 2' },
+    ], 'test');
+
+    assert.equal(env.buffer.length, env.MAX_BUFFER_SIZE);
+    assert.equal(env.buffer[0].id, 'pre1'); // pre0 was dropped
+    assert.equal(env.buffer[env.buffer.length - 1].id, 'new2');
+    assert.equal(env.buffer[env.buffer.length - 2].id, 'new1');
+  });
+
+  it('emits BUFFER_OVERFLOW trace event', () => {
+    const env = setup();
+
+    env.buffer = Array.from({ length: env.MAX_BUFFER_SIZE }, (_, i) => ({
+      id: `pre${i}`, text: `pre ${i}`,
+    }));
+
+    env.enqueueTweets([{ id: 'overflow', text: 'overflow' }], 'test');
+
+    const overflowEvents = env.traceEvents.filter(e => e.status === 'BUFFER_OVERFLOW');
+    assert.equal(overflowEvents.length, 1);
+    assert.ok(overflowEvents[0].reason.includes('dropped 1'));
+  });
+});

--- a/tests/staging-wal.test.mjs
+++ b/tests/staging-wal.test.mjs
@@ -43,6 +43,10 @@ function createMockStorage(opts = {}) {
     },
     set(items) {
       if (opts.throwOnSet) return Promise.reject(new Error('QuotaExceededError'));
+      if (opts.throwOnStagingWrite && Object.keys(items).some(k => k.startsWith('stg_')))
+        return Promise.reject(new Error('QuotaExceededError'));
+      if (opts.throwOnBufferWrite && 'tweetBuffer' in items)
+        return Promise.reject(new Error('QuotaExceededError'));
       Object.assign(data, items);
       return Promise.resolve();
     },
@@ -123,9 +127,17 @@ describe('stagePayload + clearStagedPayload', () => {
   });
 
   it('returns null on quota error', async () => {
-    const env = setup({ sessionOpts: { throwOnSet: true } });
+    const env = setup({ sessionOpts: { throwOnStagingWrite: true } });
     const key = await env.stagePayload('HomeTimeline', { foo: 1 });
     assert.equal(key, null);
+  });
+
+  it('emits STAGE_FAILED trace event on quota error', async () => {
+    const env = setup({ sessionOpts: { throwOnStagingWrite: true } });
+    await env.stagePayload('HomeTimeline', { foo: 1 });
+    const failEvents = env.traceEvents.filter(e => e.status === 'STAGE_FAILED');
+    assert.equal(failEvents.length, 1);
+    assert.equal(failEvents[0].endpoint, 'HomeTimeline');
   });
 });
 
@@ -237,6 +249,26 @@ describe('saveState / restoreState buffer persistence', () => {
     assert.ok(env.seenIds.has('1'));
     assert.ok(env.seenIds.has('2'));
     assert.ok(env.seenIds.has('3'));
+  });
+
+  it('seenIds persists even when buffer write fails (decoupled)', async () => {
+    const env = setup({ sessionOpts: { throwOnBufferWrite: true } });
+
+    env.buffer = [{ id: '1', text: 'buffered' }];
+    env.seenIds = new Set(['1', '2']);
+
+    await env.saveState();
+
+    env.buffer = [];
+    env.seenIds = new Set();
+
+    await env.restoreState();
+
+    // seenIds must survive despite buffer write failure
+    assert.ok(env.seenIds.has('1'));
+    assert.ok(env.seenIds.has('2'));
+    // buffer was not persisted
+    assert.equal(env.buffer.length, 0);
   });
 });
 

--- a/tests/staging-wal.test.mjs
+++ b/tests/staging-wal.test.mjs
@@ -45,7 +45,7 @@ function createMockStorage(opts = {}) {
       if (opts.throwOnSet) return Promise.reject(new Error('QuotaExceededError'));
       if (opts.throwOnStagingWrite && Object.keys(items).some(k => k.startsWith('stg_')))
         return Promise.reject(new Error('QuotaExceededError'));
-      if (opts.throwOnBufferWrite && 'tweetBuffer' in items)
+      if (opts.throwOnStateWrite && ('seenIds' in items || 'tweetBuffer' in items))
         return Promise.reject(new Error('QuotaExceededError'));
       Object.assign(data, items);
       return Promise.resolve();
@@ -223,6 +223,29 @@ describe('recoverStagedPayloads', () => {
     assert.equal(stored[key], undefined);
     assert.equal(env.buffer.length, 0);
   });
+
+  it('keeps WAL entry when saveState fails', async () => {
+    const env = setup({
+      extractTweets: (_ep, data) => data?.tweets || [],
+      sessionOpts: { throwOnStateWrite: true },
+    });
+
+    // Stage works (stg_* keys aren't blocked by throwOnStateWrite)
+    await env.stagePayload('HomeTimeline', {
+      tweets: [{ id: '1', text: 'tweet 1' }],
+    });
+
+    await env.recoverStagedPayloads();
+
+    // Tweet is in in-memory buffer
+    assert.equal(env.buffer.length, 1);
+    assert.equal(env.buffer[0].id, '1');
+
+    // WAL entry is retained (saveState failed → recovery kept it)
+    const stored = await env.stagingStorage().get(null);
+    const stgKeys = Object.keys(stored).filter(k => k.startsWith('stg_'));
+    assert.equal(stgKeys.length, 1);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -251,24 +274,28 @@ describe('saveState / restoreState buffer persistence', () => {
     assert.ok(env.seenIds.has('3'));
   });
 
-  it('seenIds persists even when buffer write fails (decoupled)', async () => {
-    const env = setup({ sessionOpts: { throwOnBufferWrite: true } });
+  it('returns false on storage error (coupled write)', async () => {
+    const env = setup({ sessionOpts: { throwOnStateWrite: true } });
 
     env.buffer = [{ id: '1', text: 'buffered' }];
-    env.seenIds = new Set(['1', '2']);
+    env.seenIds = new Set(['1']);
 
-    await env.saveState();
+    const ok = await env.saveState();
+    assert.equal(ok, false);
 
+    // Neither seenIds nor buffer should be in storage
     env.buffer = [];
     env.seenIds = new Set();
-
     await env.restoreState();
-
-    // seenIds must survive despite buffer write failure
-    assert.ok(env.seenIds.has('1'));
-    assert.ok(env.seenIds.has('2'));
-    // buffer was not persisted
     assert.equal(env.buffer.length, 0);
+    assert.equal(env.seenIds.size, 0);
+  });
+
+  it('returns true on success', async () => {
+    const env = setup();
+    env.buffer = [{ id: '1', text: 'buffered' }];
+    const ok = await env.saveState();
+    assert.equal(ok, true);
   });
 });
 


### PR DESCRIPTION
## Summary
- **Write-ahead log (WAL)**: Stage raw GraphQL payloads to `chrome.storage.session` before async processing; clear only after buffer+seenIds are persisted — eliminates silent tweet loss on SW suspension mid-flight
- **Buffer persistence**: `saveState()`/`restoreState()` now include `tweetBuffer` alongside `seenIds`, and `flush()` failure paths persist the buffer — prevents ghost dedup entries from tweets lost on SW termination
- **Buffer overflow cap**: Drops oldest tweets at 2000 limit with `BUFFER_OVERFLOW` trace event — bounds memory under extended daemon-offline scenarios
- **Startup recovery**: `recoverStagedPayloads()` re-parses any leftover WAL entries before `readyResolve()`, with 24h TTL and per-entry error handling

Closes #9

## Test plan
- [x] `node --test tests/staging-wal.test.mjs` — 10 new tests covering staging round-trip, quota handling, recovery (with dedup, TTL, parse errors), buffer persistence, and overflow
- [x] All 79 existing tests still pass
- [ ] Manual: kill SW via `chrome://serviceworker-internals` while browsing X → verify tweets recover on restart (console `RECOVERY_COMPLETE`)
- [ ] Manual: stop daemon, browse until buffer grows → verify console warning at 2000 cap
- [ ] Manual: normal browsing → verify no double-processing (check trace events)