### PR TITLE
fix: scale yt-dlp progress across multi-stream downloads

### DIFF
--- a/native-host/xtap_core.py
+++ b/native-host/xtap_core.py
@@ -251,6 +251,10 @@ def _download_with_ytdlp(download_id, tweet_url, video_dir, post_date=''):  # pr
         text=True,
     )
     progress_re = re.compile(r'(\d+\.?\d*)%')
+    format_re = re.compile(r'Downloading (\d+) format')
+    total_streams = 1
+    stream_index = 0
+    dest_count = 0
     final_path = None
     last_lines = []
     for line in proc.stdout:
@@ -260,15 +264,31 @@ def _download_with_ytdlp(download_id, tweet_url, video_dir, post_date=''):  # pr
             if len(last_lines) > 20:
                 last_lines.pop(0)
             print(f'[yt-dlp] {line}', file=sys.stderr)
-        # Parse progress percentage
+        # Detect multi-stream downloads ("Downloading 2 format(s): video+audio")
+        fm = format_re.search(line)
+        if fm:
+            total_streams = max(1, int(fm.group(1)))
+        # Parse progress percentage, scaled across streams
         m = progress_re.search(line)
         if m:
+            raw_pct = float(m.group(1))
+            effective_pct = min(
+                (stream_index * 100 + raw_pct) / total_streams, 100.0)
             with _downloads_lock:
-                _downloads[download_id]['progress'] = float(m.group(1))
+                _downloads[download_id]['progress'] = effective_pct
         # Capture output filename from [download] or [Merger] lines
         if 'Destination:' in line:
+            dest_count += 1
+            stream_index = min(dest_count - 1, total_streams - 1)
             final_path = line.split('Destination:', 1)[1].strip()
         elif 'has already been downloaded' in line:
+            dest_count += 1
+            stream_index = min(dest_count - 1, total_streams - 1)
+            # Count cached stream as complete for progress
+            effective_pct = min(
+                (stream_index + 1) * 100 / total_streams, 100.0)
+            with _downloads_lock:
+                _downloads[download_id]['progress'] = effective_pct
             # "[download] <path> has already been downloaded"
             part = line.split(']', 1)[1].strip() if ']' in line else line
             final_path = part.replace(' has already been downloaded', '').strip()

--- a/native-host/xtap_core.py
+++ b/native-host/xtap_core.py
@@ -251,7 +251,7 @@ def _download_with_ytdlp(download_id, tweet_url, video_dir, post_date=''):  # pr
         text=True,
     )
     progress_re = re.compile(r'(\d+\.?\d*)%')
-    format_re = re.compile(r'Downloading (\d+) format')
+    format_re = re.compile(r'Downloading \d+ format\(s\): (.+)')
     total_streams = 1
     stream_index = 0
     dest_count = 0
@@ -264,10 +264,10 @@ def _download_with_ytdlp(download_id, tweet_url, video_dir, post_date=''):  # pr
             if len(last_lines) > 20:
                 last_lines.pop(0)
             print(f'[yt-dlp] {line}', file=sys.stderr)
-        # Detect multi-stream downloads ("Downloading 2 format(s): video+audio")
+        # Detect multi-stream downloads ("Downloading 1 format(s): hls-707+hls-audio")
         fm = format_re.search(line)
         if fm:
-            total_streams = max(1, int(fm.group(1)))
+            total_streams = max(1, fm.group(1).count('+') + 1)
         # Parse progress percentage, scaled across streams
         m = progress_re.search(line)
         if m:

--- a/native-host/xtap_core.py
+++ b/native-host/xtap_core.py
@@ -227,6 +227,73 @@ def start_download(download_id, tweet_url, direct_url, out_dir, post_date=''):  
     t.start()
 
 
+class _YtdlpProgress:
+    """Parse yt-dlp stdout and scale progress across multiple HLS streams.
+
+    Call feed(line) for each stripped stdout line.  Read .progress for the
+    current 0-100 value and .final_path for the last detected output path.
+    """
+
+    _progress_re = re.compile(r'(\d+\.?\d*)%')
+    _format_re = re.compile(r'Downloading \d+ format\(s\): (.+)')
+
+    def __init__(self):
+        self.total_streams = 1
+        self.stream_index = 0
+        self.dest_count = 0
+        self.progress = 0.0
+        self.final_path = None
+
+    def feed(self, line: str):
+        # Detect multi-stream downloads by counting '+' in format string
+        # ("Downloading 1 format(s): hls-707+hls-audio" -> 2 streams)
+        if line.startswith('[info]'):
+            fm = self._format_re.search(line)
+            if fm:
+                self.total_streams = max(1, fm.group(1).count('+') + 1)
+
+        # Parse progress percentage, scaled across streams.
+        # Exclude Destination / already-downloaded lines so a tweet title
+        # containing "%" (e.g. "100% agree") doesn't poison progress.
+        if line.startswith('[download]') and 'Destination:' not in line and 'has already been downloaded' not in line:
+            m = self._progress_re.search(line)
+            if m:
+                raw_pct = float(m.group(1))
+                pct = min((self.stream_index * 100 + raw_pct) / self.total_streams, 100.0)
+                # Never report backward progress (safety net if stream
+                # count detection is wrong or yt-dlp format changes)
+                if pct >= self.progress:
+                    self.progress = pct
+
+        # Capture output filename from [download] or [Merger] lines
+        if 'Destination:' in line:
+            self.dest_count += 1
+            if self.dest_count > self.total_streams:
+                # More streams than the format line indicated (or format
+                # line was missing).  Recalibrate so the monotonic guard
+                # doesn't lock progress at 100% for the rest of the download.
+                self.total_streams = self.dest_count
+                self.progress = min(
+                    self.progress,
+                    (self.dest_count - 1) * 100.0 / self.total_streams)
+            self.stream_index = min(self.dest_count - 1, self.total_streams - 1)
+            self.final_path = line.split('Destination:', 1)[1].strip()
+        elif 'has already been downloaded' in line:
+            self.dest_count += 1
+            if self.dest_count > self.total_streams:
+                self.total_streams = self.dest_count
+            self.stream_index = min(self.dest_count - 1, self.total_streams - 1)
+            # Count cached stream as complete for progress
+            pct = min((self.stream_index + 1) * 100.0 / self.total_streams, 100.0)
+            if pct >= self.progress:
+                self.progress = pct
+            # "[download] <path> has already been downloaded"
+            part = line.split(']', 1)[1].strip() if ']' in line else line
+            self.final_path = part.replace(' has already been downloaded', '').strip()
+        elif '[Merger]' in line and 'Merging formats into' in line:
+            self.final_path = line.split('Merging formats into "', 1)[1].rstrip('"').strip() if '"' in line else self.final_path
+
+
 def _download_with_ytdlp(download_id, tweet_url, video_dir, post_date=''):  # pragma: no cover
     """Download using yt-dlp with progress parsing.
 
@@ -250,13 +317,7 @@ def _download_with_ytdlp(download_id, tweet_url, video_dir, post_date=''):  # pr
         stderr=subprocess.STDOUT,
         text=True,
     )
-    progress_re = re.compile(r'(\d+\.?\d*)%')
-    format_re = re.compile(r'Downloading \d+ format\(s\): (.+)')
-    total_streams = 1
-    stream_index = 0
-    dest_count = 0
-    reported_pct = 0.0
-    final_path = None
+    tracker = _YtdlpProgress()
     last_lines = []
     for line in proc.stdout:
         line = line.strip()
@@ -265,37 +326,9 @@ def _download_with_ytdlp(download_id, tweet_url, video_dir, post_date=''):  # pr
             if len(last_lines) > 20:
                 last_lines.pop(0)
             print(f'[yt-dlp] {line}', file=sys.stderr)
-        # Detect multi-stream downloads by counting '+' in format string
-        # ("Downloading 1 format(s): hls-707+hls-audio" → 2 streams)
-        if line.startswith('[info]'):
-            fm = format_re.search(line)
-            if fm:
-                total_streams = max(1, fm.group(1).count('+') + 1)
-        # Parse progress percentage, scaled across streams
-        if line.startswith('[download]'):
-            m = progress_re.search(line)
-            if m:
-                raw_pct = float(m.group(1))
-                pct = min((stream_index * 100 + raw_pct) / total_streams, 100.0)
-                # Never report backward progress (safety net if stream
-                # count detection is wrong or yt-dlp format changes)
-                if pct >= reported_pct:
-                    reported_pct = pct
-                    with _downloads_lock:
-                        _downloads[download_id]['progress'] = pct
-        # Capture output filename from [download] or [Merger] lines
-        if 'Destination:' in line:
-            dest_count += 1
-            stream_index = min(dest_count - 1, total_streams - 1)
-            final_path = line.split('Destination:', 1)[1].strip()
-        elif 'has already been downloaded' in line:
-            dest_count += 1
-            stream_index = min(dest_count - 1, total_streams - 1)
-            # "[download] <path> has already been downloaded"
-            part = line.split(']', 1)[1].strip() if ']' in line else line
-            final_path = part.replace(' has already been downloaded', '').strip()
-        elif '[Merger]' in line and 'Merging formats into' in line:
-            final_path = line.split('Merging formats into "', 1)[1].rstrip('"').strip() if '"' in line else final_path
+        tracker.feed(line)
+        with _downloads_lock:
+            _downloads[download_id]['progress'] = tracker.progress
     proc.wait()
     if proc.returncode != 0:
         # Include yt-dlp's error output in the exception
@@ -303,6 +336,7 @@ def _download_with_ytdlp(download_id, tweet_url, video_dir, post_date=''):  # pr
         detail = error_lines[-1] if error_lines else (last_lines[-1] if last_lines else '')
         raise RuntimeError(f'yt-dlp failed: {detail}' if detail else f'yt-dlp exited with code {proc.returncode}')
     # Move completed file from staging dir to final video_dir
+    final_path = tracker.final_path
     if final_path and os.path.isfile(final_path):
         dest_path = os.path.join(video_dir, os.path.basename(final_path))
         shutil.move(final_path, dest_path)

--- a/native-host/xtap_core.py
+++ b/native-host/xtap_core.py
@@ -255,6 +255,7 @@ def _download_with_ytdlp(download_id, tweet_url, video_dir, post_date=''):  # pr
     total_streams = 1
     stream_index = 0
     dest_count = 0
+    reported_pct = 0.0
     final_path = None
     last_lines = []
     for line in proc.stdout:
@@ -264,18 +265,24 @@ def _download_with_ytdlp(download_id, tweet_url, video_dir, post_date=''):  # pr
             if len(last_lines) > 20:
                 last_lines.pop(0)
             print(f'[yt-dlp] {line}', file=sys.stderr)
-        # Detect multi-stream downloads ("Downloading 1 format(s): hls-707+hls-audio")
-        fm = format_re.search(line)
-        if fm:
-            total_streams = max(1, fm.group(1).count('+') + 1)
+        # Detect multi-stream downloads by counting '+' in format string
+        # ("Downloading 1 format(s): hls-707+hls-audio" → 2 streams)
+        if line.startswith('[info]'):
+            fm = format_re.search(line)
+            if fm:
+                total_streams = max(1, fm.group(1).count('+') + 1)
         # Parse progress percentage, scaled across streams
-        m = progress_re.search(line)
-        if m:
-            raw_pct = float(m.group(1))
-            effective_pct = min(
-                (stream_index * 100 + raw_pct) / total_streams, 100.0)
-            with _downloads_lock:
-                _downloads[download_id]['progress'] = effective_pct
+        if line.startswith('[download]'):
+            m = progress_re.search(line)
+            if m:
+                raw_pct = float(m.group(1))
+                pct = min((stream_index * 100 + raw_pct) / total_streams, 100.0)
+                # Never report backward progress (safety net if stream
+                # count detection is wrong or yt-dlp format changes)
+                if pct >= reported_pct:
+                    reported_pct = pct
+                    with _downloads_lock:
+                        _downloads[download_id]['progress'] = pct
         # Capture output filename from [download] or [Merger] lines
         if 'Destination:' in line:
             dest_count += 1
@@ -284,11 +291,6 @@ def _download_with_ytdlp(download_id, tweet_url, video_dir, post_date=''):  # pr
         elif 'has already been downloaded' in line:
             dest_count += 1
             stream_index = min(dest_count - 1, total_streams - 1)
-            # Count cached stream as complete for progress
-            effective_pct = min(
-                (stream_index + 1) * 100 / total_streams, 100.0)
-            with _downloads_lock:
-                _downloads[download_id]['progress'] = effective_pct
             # "[download] <path> has already been downloaded"
             part = line.split(']', 1)[1].strip() if ']' in line else line
             final_path = part.replace(' has already been downloaded', '').strip()

--- a/popup.js
+++ b/popup.js
@@ -101,7 +101,13 @@ function checkForVideo() {
 
       // Show video section
       const typeLabel = resp.mediaType === 'animated_gif' ? 'GIF' : 'Video';
-      const duration = resp.durationMs ? ` (${Math.round(resp.durationMs / 1000)}s)` : '';
+      let duration = '';
+      if (resp.durationMs) {
+        const totalSec = Math.round(resp.durationMs / 1000);
+        duration = totalSec >= 60
+          ? ` (${Math.floor(totalSec / 60)}m ${totalSec % 60}s)`
+          : ` (${totalSec}s)`;
+      }
       videoLabel.textContent = `${typeLabel} detected${duration}`;
       videoSection.style.display = '';
 

--- a/tests/test_xtap_core.py
+++ b/tests/test_xtap_core.py
@@ -390,3 +390,187 @@ class TestGetDownloadStatus:
         assert result['status'] == 'done'
         assert result['path'] == '/tmp/video.mp4'
         del xtap_core._downloads['test-done']
+
+
+# ---------------------------------------------------------------------------
+# _YtdlpProgress
+# ---------------------------------------------------------------------------
+
+
+def _feed_lines(lines):
+    """Helper: feed a list of lines into a fresh _YtdlpProgress tracker."""
+    t = xtap_core._YtdlpProgress()
+    history = []
+    for line in lines:
+        t.feed(line)
+        history.append(t.progress)
+    return t, history
+
+
+class TestYtdlpProgressSingleStream:
+    def test_basic_progress(self):
+        t, h = _feed_lines([
+            '[info] 123: Downloading 1 format(s): hls-707',
+            '[download] Destination: /tmp/video.mp4',
+            '[download]   0.0%',
+            '[download]  50.0%',
+            '[download] 100.0%',
+        ])
+        assert t.progress == 100.0
+        assert t.final_path == '/tmp/video.mp4'
+
+    def test_defaults_to_single_stream(self):
+        """No format line at all — total_streams stays 1."""
+        t, h = _feed_lines([
+            '[download] Destination: /tmp/video.mp4',
+            '[download]  50.0%',
+            '[download] 100.0%',
+        ])
+        assert t.progress == 100.0
+
+
+class TestYtdlpProgressMultiStream:
+    def test_two_stream_scaling(self):
+        """Two HLS streams: progress should go 0->50->100, not 0->100->0->100."""
+        t, h = _feed_lines([
+            '[info] 123: Downloading 2 format(s): hls-707+hls-audio',
+            '[download] Destination: /tmp/video.mp4',
+            '[download]   0.0%',
+            '[download]  50.0%',
+            '[download] 100.0%',
+            '[download] Destination: /tmp/audio.m4a',
+            '[download]   0.0%',
+            '[download]  50.0%',
+            '[download] 100.0%',
+            '[Merger] Merging formats into "/tmp/final.mp4"',
+        ])
+        assert t.progress == 100.0
+        assert t.final_path == '/tmp/final.mp4'
+        # After stream 1 completes, progress should be 50%, not 100%
+        assert h[4] == 50.0  # stream 1 at 100% raw -> 50% scaled
+
+    def test_progress_never_decreases(self):
+        """Monotonic guard: progress must never go backward."""
+        t, _ = _feed_lines([
+            '[info] 123: Downloading 2 format(s): hls-707+hls-audio',
+            '[download] Destination: /tmp/video.mp4',
+            '[download]  80.0%',
+            '[download]  30.0%',  # yt-dlp quirk: lower than previous
+        ])
+        assert t.progress == 40.0  # 80% of first stream = 40% overall
+
+    def test_three_streams(self):
+        t, _ = _feed_lines([
+            '[info] 123: Downloading 3 format(s): hls-707+hls-audio+hls-subs',
+            '[download] Destination: /tmp/a.mp4',
+            '[download] 100.0%',
+            '[download] Destination: /tmp/b.m4a',
+            '[download] 100.0%',
+            '[download] Destination: /tmp/c.vtt',
+            '[download] 100.0%',
+        ])
+        # Each stream is 1/3: after stream 1=33.3, stream 2=66.7, stream 3=100
+        assert t.progress == 100.0
+
+
+class TestYtdlpProgressCachedStreams:
+    def test_cached_stream_counts_as_complete(self):
+        t, h = _feed_lines([
+            '[info] 123: Downloading 2 format(s): hls-707+hls-audio',
+            '[download] /tmp/video.mp4 has already been downloaded',
+            '[download] Destination: /tmp/audio.m4a',
+            '[download]  50.0%',
+            '[download] 100.0%',
+        ])
+        assert h[1] == 50.0  # cached stream = 50% (1 of 2 done)
+        assert t.progress == 100.0
+        assert t.final_path == '/tmp/audio.m4a'
+
+    def test_both_streams_cached(self):
+        t, _ = _feed_lines([
+            '[info] 123: Downloading 2 format(s): hls-707+hls-audio',
+            '[download] /tmp/video.mp4 has already been downloaded',
+            '[download] /tmp/audio.m4a has already been downloaded',
+        ])
+        assert t.progress == 100.0
+
+
+class TestYtdlpProgressRecalibration:
+    def test_unexpected_extra_stream(self):
+        """Format line says 1 stream, but 2 Destination lines appear."""
+        t, h = _feed_lines([
+            '[download] Destination: /tmp/video.mp4',
+            '[download] 100.0%',
+            '[download] Destination: /tmp/audio.m4a',  # surprise!
+            '[download]   0.0%',
+            '[download]  50.0%',
+            '[download] 100.0%',
+        ])
+        # After recalibration to 2 streams, should reach 100%
+        assert t.progress == 100.0
+        assert t.total_streams == 2
+
+    def test_recalibration_rewinds_progress(self):
+        """When a surprise stream appears, progress rewinds to correct value."""
+        t, h = _feed_lines([
+            '[download] Destination: /tmp/video.mp4',
+            '[download] 100.0%',  # thinks it's done: 100%
+        ])
+        assert t.progress == 100.0
+        # Now a second stream appears
+        t.feed('[download] Destination: /tmp/audio.m4a')
+        assert t.progress == 50.0  # recalibrated: 1 of 2 done
+        assert t.total_streams == 2
+
+    def test_unexpected_cached_after_live(self):
+        """Live stream finishes, then a cached stream appears unexpectedly."""
+        t, _ = _feed_lines([
+            '[download] Destination: /tmp/video.mp4',
+            '[download] 100.0%',
+            '[download] /tmp/audio.m4a has already been downloaded',
+        ])
+        assert t.progress == 100.0  # both done
+
+
+class TestYtdlpProgressPoisoning:
+    def test_percent_in_tweet_title_ignored(self):
+        """A tweet title containing '%' must not affect progress."""
+        t, h = _feed_lines([
+            '[info] 123: Downloading 1 format(s): hls-707',
+            '[download] Destination: /tmp/100% agree [123].mp4',
+            '[download]  25.0%',
+        ])
+        assert t.progress == 25.0  # not 100
+
+    def test_non_download_line_with_percent(self):
+        """Lines not starting with [download] are ignored for progress."""
+        t, _ = _feed_lines([
+            '[info] 123: 100% of something',
+            '[download] Destination: /tmp/video.mp4',
+            '[download]  10.0%',
+        ])
+        assert t.progress == 10.0
+
+    def test_already_downloaded_line_with_percent(self):
+        """'has already been downloaded' lines don't trigger progress regex."""
+        t, _ = _feed_lines([
+            '[info] 123: Downloading 2 format(s): hls-707+hls-audio',
+            '[download] /tmp/50% off [123].mp4 has already been downloaded',
+            '[download] Destination: /tmp/audio.m4a',
+            '[download]  60.0%',
+        ])
+        # Cached stream = 50% (1 of 2), then 60% of stream 2 = 80% overall
+        assert t.progress == 80.0
+
+
+class TestYtdlpProgressMerger:
+    def test_merger_updates_final_path(self):
+        t, _ = _feed_lines([
+            '[info] 123: Downloading 2 format(s): hls-707+hls-audio',
+            '[download] Destination: /tmp/video.mp4',
+            '[download] 100.0%',
+            '[download] Destination: /tmp/audio.m4a',
+            '[download] 100.0%',
+            '[Merger] Merging formats into "/tmp/final.mp4"',
+        ])
+        assert t.final_path == '/tmp/final.mp4'


### PR DESCRIPTION
Closes #25

## Summary
- yt-dlp downloads video and audio as separate HLS streams, each reporting 0→100% independently — the UI showed progress resetting to 0% mid-download
- Detect stream count from yt-dlp's `Downloading N format(s)` line and scale per-stream progress into a single continuous 0–100% range: `effective_pct = (stream_index × 100 + raw_pct) / total_streams`
- Single-stream downloads are unaffected (total_streams defaults to 1)

## Edge cases handled
- **Already-downloaded streams**: counted as complete, progress jumps to their full slice
- **Format line missing**: defaults to 1 stream (no-op scaling)
- **Unexpected extra destinations**: `stream_index` clamped to `total_streams - 1`

## Test plan
- [x] Existing 69 tests pass
- [x] Manual test: download a tweet with video (2-stream HLS) — verify smooth 0→50→100% progression
- [x] Manual test: download a tweet with video (single stream) — verify no regression