### PR TITLE
Hide download button for already-downloaded videos

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,8 @@ background.js (Service Worker, ES module)
 │   Managed by launchd (macOS), systemd (Linux), Scheduled Task  │
 │   (Windows). Bearer token auth from ~/.xtap/secret             │
 │   Endpoints: GET /status, POST /tweets, /log, /test-path,     │
-│   /check-ytdlp, /download-video, /download-status             │
+│   /check-ytdlp, /check-video-file, /download-video,           │
+│   /download-status                                            │
 └────────────────────────────────────────────────────────────────┘
 ┌─── Native messaging (token bootstrap only) ───────────────────┐
 │ xtap_host.py (Python, stdio)                                   │
@@ -50,7 +51,7 @@ debug-YYYY-MM-DD.log     (when debug logging enabled)
 - **Random event channel:** The CustomEvent name is generated per page load (`'_' + Math.random().toString(36).slice(2)`) and passed via a `<meta>` tag that's immediately removed. Avoids predictable DOM markers.
 - **HTTP-only transport:** All data flows through the HTTP daemon (`xtap_daemon.py`), managed by launchd (macOS), systemd (Linux), or Scheduled Task (Windows). On macOS, it runs outside browser TCC sandboxes, allowing writes to protected paths. If the daemon goes down, tweets are buffered in memory and the extension reprobes every 30 seconds until the daemon recovers.
 - **Token bootstrap via native messaging:** On first run, the extension connects to `xtap_host.py` via native messaging to request `GET_TOKEN` (reads `~/.xtap/secret`). The token is cached in `chrome.storage.local` for subsequent HTTP requests. The native host handles nothing else — all data goes through HTTP.
-- **Shared core logic:** `xtap_core.py` contains all file I/O logic (load seen IDs, resolve output dir, write tweets/logs, test path), used by `xtap_daemon.py`.
+- **Shared core logic:** `xtap_core.py` contains all file I/O logic (load seen IDs, resolve output dir, write tweets/logs, test path, existing-video lookup), used by `xtap_daemon.py`.
 - **Environment detection:** `isDevMode = !chrome.runtime.getManifest().update_url` — packed CWS extensions have `update_url`, unpacked don't. Used to switch seenIds storage between session (dev) and local (production).
 - **Volatile dev cache:** In dev mode (unpacked), `seenIds` is stored in `chrome.storage.session`, which clears on extension reload. This eliminates the need to manually clear storage during development. Production behavior is unchanged (persisted to `chrome.storage.local`).
 - **Dedup in service worker:** Multiple tabs feed the same service worker. `seenIds` Set (max 50,000, FIFO eviction) prevents duplicates. In production, persisted to `chrome.storage.local` across sessions; in dev mode, uses volatile `chrome.storage.session`. Both host and daemon also load seen IDs from existing JSONL files on startup.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ xTap is a browser extension (Chrome + Firefox) that silently intercepts the Grap
 - **Zero footprint** — no additional network requests; captures what your browser already receives
 - **Structured output** — each tweet saved as a clean JSON object with author, metrics, media, and more
 - **Article support** — long-form X articles are captured with full text, inline image references, and Draft.js block structure
-- **Video download** — download videos from tweets using yt-dlp (or direct MP4 fallback) via the extension popup. Already-downloaded videos are detected in the output directory and shown as downloaded instead of offered again. Requires the HTTP daemon. **Note:** unlike passive capture, video downloads make additional network requests to X and are not stealth.
+- **Video download** — download videos from tweets using yt-dlp (or direct MP4 fallback) via the extension popup. Requires the HTTP daemon. **Note:** unlike passive capture, video downloads make additional network requests to X and are not stealth.
 - **Pause / resume** — click the extension icon to toggle capture on the fly
 - **Live counter** — badge on the extension icon shows tweets captured this session
 - **Multi-tab aware** — multiple X tabs feed into the same service worker with shared deduplication

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ xTap is a browser extension (Chrome + Firefox) that silently intercepts the Grap
 - **Zero footprint** — no additional network requests; captures what your browser already receives
 - **Structured output** — each tweet saved as a clean JSON object with author, metrics, media, and more
 - **Article support** — long-form X articles are captured with full text, inline image references, and Draft.js block structure
-- **Video download** — download videos from tweets using yt-dlp (or direct MP4 fallback) via the extension popup. Requires the HTTP daemon. **Note:** unlike passive capture, video downloads make additional network requests to X and are not stealth.
+- **Video download** — download videos from tweets using yt-dlp (or direct MP4 fallback) via the extension popup. Already-downloaded videos are detected in the output directory and shown as downloaded instead of offered again. Requires the HTTP daemon. **Note:** unlike passive capture, video downloads make additional network requests to X and are not stealth.
 - **Pause / resume** — click the extension icon to toggle capture on the fly
 - **Live counter** — badge on the extension icon shows tweets captured this session
 - **Multi-tab aware** — multiple X tabs feed into the same service worker with shared deduplication

--- a/background.js
+++ b/background.js
@@ -330,6 +330,10 @@ async function sendToHost(msg) {
   } else if (msg.type === 'CHECK_YTDLP') {
     path = '/check-ytdlp';
     body = {};
+  } else if (msg.type === 'CHECK_VIDEO_FILE') {
+    path = '/check-video-file';
+    body = { tweetUrl: msg.tweetUrl };
+    if (msg.outputDir) body.outputDir = msg.outputDir;
   } else if (msg.type === 'DOWNLOAD_VIDEO') {
     path = '/download-video';
     body = { tweetUrl: msg.tweetUrl, directUrl: msg.directUrl, postDate: msg.postDate };
@@ -730,25 +734,47 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
   }
 
   if (msg.type === 'CHECK_VIDEO') {
-    const tweet = recentTweets.get(msg.tweetId);
-    if (!tweet || !tweet.media || tweet.media.length === 0) {
-      sendResponse({ hasVideo: false });
-      return true;
-    }
-    const videoMedia = tweet.media.find(m => m.type === 'video' || m.type === 'animated_gif');
-    if (!videoMedia) {
-      sendResponse({ hasVideo: false });
-      return true;
-    }
-    sendResponse({
-      hasVideo: true,
-      tweetUrl: tweet.url || `https://x.com/i/status/${msg.tweetId}`,
-      directUrl: videoMedia.url || null,
-      mediaType: videoMedia.type,
-      durationMs: videoMedia.duration_ms || null,
-      postDate: tweet.created_at || null,
-      activeDownloadId: activeDownloads.get(msg.tweetId) || null,
-    });
+    (async () => {
+      const tweet = recentTweets.get(msg.tweetId);
+      if (!tweet || !tweet.media || tweet.media.length === 0) {
+        sendResponse({ hasVideo: false });
+        return;
+      }
+      const videoMedia = tweet.media.find(m => m.type === 'video' || m.type === 'animated_gif');
+      if (!videoMedia) {
+        sendResponse({ hasVideo: false });
+        return;
+      }
+
+      const tweetUrl = tweet.url || `https://x.com/i/status/${msg.tweetId}`;
+      const response = {
+        hasVideo: true,
+        tweetUrl,
+        directUrl: videoMedia.url || null,
+        mediaType: videoMedia.type,
+        durationMs: videoMedia.duration_ms || null,
+        postDate: tweet.created_at || null,
+        activeDownloadId: activeDownloads.get(msg.tweetId) || null,
+        alreadyDownloaded: false,
+        downloadedPath: null,
+      };
+
+      try {
+        const fileResp = await sendToHost({
+          type: 'CHECK_VIDEO_FILE',
+          tweetUrl,
+          outputDir: outputDir || undefined,
+        });
+        if (fileResp?.ok && fileResp.exists) {
+          response.alreadyDownloaded = true;
+          response.downloadedPath = fileResp.path || null;
+        }
+      } catch (e) {
+        console.warn('[xTap] Video file check failed:', e.message);
+      }
+
+      sendResponse(response);
+    })();
     return true;
   }
 

--- a/native-host/xtap_core.py
+++ b/native-host/xtap_core.py
@@ -137,6 +137,7 @@ _ytdlp_path = None
 _ytdlp_checked = False
 _downloads = {}
 _downloads_lock = threading.Lock()
+_VIDEO_EXTENSIONS = {'.mp4', '.m4v', '.mov', '.webm', '.mkv'}
 
 
 def check_ytdlp():  # pragma: no cover
@@ -174,6 +175,35 @@ def _date_prefix(post_date):
         return ''
 
 
+def _tweet_id_from_url(tweet_url):
+    """Extract a tweet/status ID from an X/Twitter status URL."""
+    m = re.search(r'/status/(\d+)', tweet_url or '')
+    return m.group(1) if m else ''
+
+
+def find_existing_video(tweet_url, out_dir):
+    """Return an existing downloaded video path for tweet_url, or None."""
+    tweet_id = _tweet_id_from_url(tweet_url)
+    if not tweet_id:
+        return None
+
+    video_dir = os.path.join(out_dir, 'videos')
+    if not os.path.isdir(video_dir):
+        return None
+
+    id_re = re.compile(rf'(^|[^0-9]){re.escape(tweet_id)}([^0-9]|$)')
+    for name in sorted(os.listdir(video_dir)):
+        path = os.path.join(video_dir, name)
+        if not os.path.isfile(path) or name.endswith('.part'):
+            continue
+        stem, ext = os.path.splitext(name)
+        if ext.lower() not in _VIDEO_EXTENSIONS:
+            continue
+        if name == f'{tweet_id}{ext}' or id_re.search(stem):
+            return path
+    return None
+
+
 def download_direct(direct_url, tweet_id, video_dir, post_date=''):  # pragma: no cover
     """Download video via direct CDN URL. Returns the file path."""
     os.makedirs(video_dir, exist_ok=True)
@@ -207,8 +237,7 @@ def start_download(download_id, tweet_url, direct_url, out_dir, post_date=''):  
                 with _downloads_lock:
                     _downloads[download_id]['progress'] = 0
                 # Extract tweet ID from URL
-                m = re.search(r'/status/(\d+)', tweet_url)
-                tweet_id = m.group(1) if m else download_id
+                tweet_id = _tweet_id_from_url(tweet_url) or download_id
                 path = download_direct(direct_url, tweet_id, video_dir, post_date)
                 with _downloads_lock:
                     _downloads[download_id].update(

--- a/native-host/xtap_core.py
+++ b/native-host/xtap_core.py
@@ -204,6 +204,13 @@ def find_existing_video(tweet_url, out_dir):
     return None
 
 
+def _ytdlp_output_template(staging_dir, tweet_url, post_date=''):
+    prefix = _date_prefix(post_date)
+    tweet_id = _tweet_id_from_url(tweet_url)
+    id_part = f' [{tweet_id}]' if tweet_id else ' [%(id)s]'
+    return os.path.join(staging_dir, prefix + '%(title)s' + id_part + '.%(ext)s')
+
+
 def download_direct(direct_url, tweet_id, video_dir, post_date=''):  # pragma: no cover
     """Download video via direct CDN URL. Returns the file path."""
     os.makedirs(video_dir, exist_ok=True)
@@ -331,8 +338,7 @@ def _download_with_ytdlp(download_id, tweet_url, video_dir, post_date=''):  # pr
     """
     staging_dir = os.path.join(video_dir, '.downloading')
     os.makedirs(staging_dir, exist_ok=True)
-    prefix = _date_prefix(post_date)
-    output_template = os.path.join(staging_dir, prefix + '%(title)s [%(id)s].%(ext)s')
+    output_template = _ytdlp_output_template(staging_dir, tweet_url, post_date)
     cmd = [
         _ytdlp_path,
         '--newline', '--progress',

--- a/native-host/xtap_core.py
+++ b/native-host/xtap_core.py
@@ -137,7 +137,7 @@ _ytdlp_path = None
 _ytdlp_checked = False
 _downloads = {}
 _downloads_lock = threading.Lock()
-_video_extensions = {'.mp4', '.m4v', '.mov', '.webm', '.mkv'}
+_video_extensions = {'.mp4'}
 
 
 def check_ytdlp():  # pragma: no cover

--- a/native-host/xtap_core.py
+++ b/native-host/xtap_core.py
@@ -137,7 +137,7 @@ _ytdlp_path = None
 _ytdlp_checked = False
 _downloads = {}
 _downloads_lock = threading.Lock()
-_VIDEO_EXTENSIONS = {'.mp4', '.m4v', '.mov', '.webm', '.mkv'}
+_video_extensions = {'.mp4', '.m4v', '.mov', '.webm', '.mkv'}
 
 
 def check_ytdlp():  # pragma: no cover
@@ -197,7 +197,7 @@ def find_existing_video(tweet_url, out_dir):
         if not os.path.isfile(path) or name.endswith('.part'):
             continue
         stem, ext = os.path.splitext(name)
-        if ext.lower() not in _VIDEO_EXTENSIONS:
+        if ext.lower() not in _video_extensions:
             continue
         if name == f'{tweet_id}{ext}' or id_re.search(stem):
             return path

--- a/native-host/xtap_daemon.py
+++ b/native-host/xtap_daemon.py
@@ -15,7 +15,8 @@ from http.server import ThreadingHTTPServer, BaseHTTPRequestHandler
 from xtap_core import (DEFAULT_OUTPUT_DIR, load_seen_ids, resolve_output_dir,
                        validate_output_dir, write_tweets, write_log,
                        write_dump, test_path,
-                       check_ytdlp, start_download, get_download_status)
+                       check_ytdlp, start_download, get_download_status,
+                       find_existing_video)
 
 VERSION = '0.22.0'
 BIND_HOST = '127.0.0.1'
@@ -138,6 +139,8 @@ class DaemonHandler(BaseHTTPRequestHandler):
             self._handle_test_path(body)
         elif self.path == '/check-ytdlp':
             self._handle_check_ytdlp(body)
+        elif self.path == '/check-video-file':
+            self._handle_check_video_file(body)
         elif self.path == '/download-video':
             self._handle_download_video(body)
         elif self.path == '/download-status':
@@ -213,6 +216,21 @@ class DaemonHandler(BaseHTTPRequestHandler):
         available = check_ytdlp()
         log_debug(f'  yt-dlp available: {available}')
         self._send_json({'ok': True, 'available': available})
+
+    def _handle_check_video_file(self, body):
+        try:
+            tweet_url = body.get('tweetUrl', '')
+            msg_dir = body.get('outputDir', '').strip()
+            with _state_lock:
+                out_dir = resolve_output_dir(msg_dir, DEFAULT_OUTPUT_DIR, _seen_ids, _custom_dirs)
+            path = find_existing_video(tweet_url, out_dir)
+            log_debug(f'  Video file exists: {bool(path)} -> {tweet_url}')
+            self._send_json({'ok': True, 'exists': bool(path), 'path': path})
+        except ValueError as e:
+            self._send_json({'ok': False, 'error': str(e)}, 400)
+        except Exception as e:
+            log_info(f'ERROR /check-video-file: {e}')
+            self._send_json({'ok': False, 'error': str(e)}, 500)
 
     def _handle_download_video(self, body):
         try:

--- a/popup.css
+++ b/popup.css
@@ -154,6 +154,16 @@ button.paused {
   color: #f87171;
 }
 
+.download-status {
+  background: #0d3b1e;
+  color: #4ade80;
+  border-radius: 6px;
+  font-size: 14px;
+  font-weight: 600;
+  padding: 10px 14px;
+  text-align: center;
+}
+
 .settings {
   margin-top: 14px;
   border-top: 1px solid #2f3336;

--- a/popup.html
+++ b/popup.html
@@ -28,6 +28,7 @@
         Install <a href="https://github.com/yt-dlp/yt-dlp#installation" target="_blank">yt-dlp</a> for best quality
       </div>
       <div class="video-warning">Not stealth — downloads make extra requests to X</div>
+      <div id="download-status" class="download-status" style="display: none;"></div>
       <button id="download-btn" class="download-btn"></button>
     </div>
     <div class="settings">

--- a/popup.js
+++ b/popup.js
@@ -9,6 +9,7 @@ const videoSection = document.getElementById('video-section');
 const videoLabel = document.getElementById('video-label');
 const ytdlpHint = document.getElementById('ytdlp-hint');
 const downloadBtn = document.getElementById('download-btn');
+const downloadStatus = document.getElementById('download-status');
 
 function render(state) {
   sessionEl.textContent = state.sessionCount.toLocaleString();
@@ -81,6 +82,7 @@ saveDirBtn.addEventListener('click', () => {
 let pollTimer = null;
 let currentTransport = null;
 let videoChecked = false;
+let idleDownloadLabel = 'Download Video';
 
 function checkForVideo() {
   // Video download requires the HTTP daemon
@@ -113,6 +115,8 @@ function checkForVideo() {
 
       // Resume polling if there's an active download for this tweet
       if (resp.activeDownloadId) {
+        downloadStatus.style.display = 'none';
+        downloadBtn.style.display = '';
         downloadBtn.textContent = 'Downloading...';
         downloadBtn.className = 'download-btn downloading';
         downloadBtn.disabled = true;
@@ -120,15 +124,25 @@ function checkForVideo() {
         return;
       }
 
+      if (resp.alreadyDownloaded) {
+        showAlreadyDownloaded();
+        return;
+      }
+
       // Check yt-dlp availability
       chrome.runtime.sendMessage({ type: 'CHECK_YTDLP' }, (ytResp) => {
         const hasYtdlp = ytResp && ytResp.ok && ytResp.available;
         if (hasYtdlp) {
-          downloadBtn.textContent = 'Download Video';
+          idleDownloadLabel = 'Download Video';
         } else {
           ytdlpHint.style.display = '';
-          downloadBtn.textContent = 'Download MP4';
+          idleDownloadLabel = 'Download MP4';
         }
+        downloadStatus.style.display = 'none';
+        downloadBtn.style.display = '';
+        downloadBtn.textContent = idleDownloadLabel;
+        downloadBtn.className = 'download-btn';
+        downloadBtn.disabled = false;
 
         downloadBtn.onclick = () => startDownload(tweetId, resp.tweetUrl, resp.directUrl, resp.postDate);
       });
@@ -137,6 +151,8 @@ function checkForVideo() {
 }
 
 function startDownload(tweetId, tweetUrl, directUrl, postDate) {
+  downloadStatus.style.display = 'none';
+  downloadBtn.style.display = '';
   downloadBtn.disabled = true;
   downloadBtn.textContent = 'Starting...';
   downloadBtn.className = 'download-btn downloading';
@@ -172,9 +188,11 @@ function pollDownload(downloadId) {
         }
       } else if (resp.status === 'done') {
         clearInterval(pollTimer);
+        pollTimer = null;
         showDownloadResult('success', 'Download complete');
       } else if (resp.status === 'error') {
         clearInterval(pollTimer);
+        pollTimer = null;
         showDownloadResult('error', resp.error || 'Download failed');
       }
     });
@@ -182,14 +200,35 @@ function pollDownload(downloadId) {
 }
 
 function showDownloadResult(type, message) {
+  downloadStatus.style.display = 'none';
+  downloadBtn.style.display = '';
   downloadBtn.textContent = message;
   downloadBtn.className = `download-btn ${type}`;
   downloadBtn.disabled = true;
-  setTimeout(() => {
-    downloadBtn.textContent = 'Download Video';
-    downloadBtn.className = 'download-btn';
-    downloadBtn.disabled = false;
-  }, 3000);
+  if (type === 'success') {
+    setTimeout(() => showAlreadyDownloaded(), 3000);
+  } else {
+    setTimeout(() => {
+      downloadStatus.style.display = 'none';
+      downloadBtn.style.display = '';
+      downloadBtn.textContent = idleDownloadLabel;
+      downloadBtn.className = 'download-btn';
+      downloadBtn.disabled = false;
+    }, 3000);
+  }
+}
+
+function showAlreadyDownloaded() {
+  if (pollTimer) {
+    clearInterval(pollTimer);
+    pollTimer = null;
+  }
+  ytdlpHint.style.display = 'none';
+  downloadStatus.textContent = 'Already downloaded';
+  downloadStatus.style.display = '';
+  downloadBtn.style.display = 'none';
+  downloadBtn.disabled = true;
+  downloadBtn.onclick = null;
 }
 
 document.getElementById('open-debug').addEventListener('click', () => {

--- a/popup.js
+++ b/popup.js
@@ -173,6 +173,7 @@ function startDownload(tweetId, tweetUrl, directUrl, postDate) {
 }
 
 function pollDownload(downloadId) {
+  if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
   pollTimer = setInterval(() => {
     chrome.runtime.sendMessage({
       type: 'DOWNLOAD_STATUS',

--- a/tests/test_xtap_core.py
+++ b/tests/test_xtap_core.py
@@ -74,6 +74,27 @@ class TestFindExistingVideo:
 
 
 # ---------------------------------------------------------------------------
+# _ytdlp_output_template
+# ---------------------------------------------------------------------------
+
+
+class TestYtdlpOutputTemplate:
+    def test_uses_tweet_id_from_url(self, tmp_path):
+        template = xtap_core._ytdlp_output_template(
+            str(tmp_path),
+            'https://x.com/user/status/12345',
+            '2024-01-15T12:34:56.000Z',
+        )
+
+        assert template == os.path.join(str(tmp_path), '2024.01.15_%(title)s [12345].%(ext)s')
+
+    def test_falls_back_to_ytdlp_id_without_status_url(self, tmp_path):
+        template = xtap_core._ytdlp_output_template(str(tmp_path), 'https://x.com/user')
+
+        assert template == os.path.join(str(tmp_path), '%(title)s [%(id)s].%(ext)s')
+
+
+# ---------------------------------------------------------------------------
 # load_seen_ids
 # ---------------------------------------------------------------------------
 

--- a/tests/test_xtap_core.py
+++ b/tests/test_xtap_core.py
@@ -34,6 +34,46 @@ class TestDatePrefix:
 
 
 # ---------------------------------------------------------------------------
+# find_existing_video
+# ---------------------------------------------------------------------------
+
+
+class TestFindExistingVideo:
+    def test_missing_video_dir(self, tmp_path):
+        assert xtap_core.find_existing_video('https://x.com/u/status/12345', str(tmp_path)) is None
+
+    def test_direct_download_filename(self, tmp_path):
+        video_dir = tmp_path / 'videos'
+        video_dir.mkdir()
+        path = video_dir / '2024.01.15_12345.mp4'
+        path.write_bytes(b'video')
+
+        assert xtap_core.find_existing_video('https://x.com/u/status/12345', str(tmp_path)) == str(path)
+
+    def test_ytdlp_filename(self, tmp_path):
+        video_dir = tmp_path / 'videos'
+        video_dir.mkdir()
+        path = video_dir / 'Example title [12345].mp4'
+        path.write_bytes(b'video')
+
+        assert xtap_core.find_existing_video('https://twitter.com/u/status/12345', str(tmp_path)) == str(path)
+
+    def test_substring_id_does_not_match(self, tmp_path):
+        video_dir = tmp_path / 'videos'
+        video_dir.mkdir()
+        (video_dir / 'Example title [9123456].mp4').write_bytes(b'video')
+
+        assert xtap_core.find_existing_video('https://x.com/u/status/12345', str(tmp_path)) is None
+
+    def test_partial_files_are_ignored(self, tmp_path):
+        video_dir = tmp_path / 'videos'
+        video_dir.mkdir()
+        (video_dir / '12345.mp4.part').write_bytes(b'partial')
+
+        assert xtap_core.find_existing_video('https://x.com/u/status/12345', str(tmp_path)) is None
+
+
+# ---------------------------------------------------------------------------
 # load_seen_ids
 # ---------------------------------------------------------------------------
 

--- a/tests/test_xtap_daemon.py
+++ b/tests/test_xtap_daemon.py
@@ -243,6 +243,57 @@ class TestAuthorizedRequest:
 
 
 # ---------------------------------------------------------------------------
+# Tests — Video file checks
+# ---------------------------------------------------------------------------
+
+class TestVideoFileCheck:
+
+    def test_check_video_file_existing(self, daemon_url):
+        import shutil
+        import tempfile
+
+        out_dir = tempfile.mkdtemp(dir=os.path.expanduser('~'), prefix='.xtap-test-')
+        try:
+            video_dir = os.path.join(out_dir, 'videos')
+            os.makedirs(video_dir)
+            video_path = os.path.join(video_dir, 'Example title [12345].mp4')
+            with open(video_path, 'wb') as f:
+                f.write(b'video')
+
+            status, body = _post(
+                daemon_url, '/check-video-file',
+                body={'outputDir': out_dir, 'tweetUrl': 'https://x.com/u/status/12345'},
+                token=TEST_TOKEN,
+            )
+
+            assert status == 200
+            assert body['ok'] is True
+            assert body['exists'] is True
+            assert body['path'] == video_path
+        finally:
+            shutil.rmtree(out_dir, ignore_errors=True)
+
+    def test_check_video_file_missing(self, daemon_url):
+        import shutil
+        import tempfile
+
+        out_dir = tempfile.mkdtemp(dir=os.path.expanduser('~'), prefix='.xtap-test-')
+        try:
+            status, body = _post(
+                daemon_url, '/check-video-file',
+                body={'outputDir': out_dir, 'tweetUrl': 'https://x.com/u/status/12345'},
+                token=TEST_TOKEN,
+            )
+
+            assert status == 200
+            assert body['ok'] is True
+            assert body['exists'] is False
+            assert body['path'] is None
+        finally:
+            shutil.rmtree(out_dir, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
 # Tests — Concurrency (issue #8)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- add a daemon-backed check for existing downloaded video files before showing the popup download action
- hide the download button and show an already-downloaded status when a matching file exists
- keep completed downloads in the downloaded state instead of re-enabling the action
- cover existing-video detection and the daemon endpoint with tests

Closes #28.

## Validation

- `python3 -m pytest tests/ -q`
- `node --test tests/*.test.mjs`
- `node --check background.js`
- `node --check popup.js`
- `git diff --check`