### PR TITLE
fix: pin tweet status ID in downloaded video filename

### DIFF
--- a/native-host/xtap_core.py
+++ b/native-host/xtap_core.py
@@ -303,7 +303,12 @@ def _download_with_ytdlp(download_id, tweet_url, video_dir, post_date=''):  # pr
     staging_dir = os.path.join(video_dir, '.downloading')
     os.makedirs(staging_dir, exist_ok=True)
     prefix = _date_prefix(post_date)
-    output_template = os.path.join(staging_dir, prefix + '%(title)s [%(id)s].%(ext)s')
+    # Pin the tweet status ID in the filename rather than relying on %(id)s,
+    # which some yt-dlp Twitter sub-extractors (amplify/broadcast/card) fill
+    # with a media or broadcast ID instead of the tweet ID.
+    m = re.search(r'/status/(\d+)', tweet_url)
+    id_part = m.group(1) if m else '%(id)s'
+    output_template = os.path.join(staging_dir, prefix + '%(title)s [' + id_part + '].%(ext)s')
     cmd = [
         _ytdlp_path,
         '--newline', '--progress',


### PR DESCRIPTION
## Summary
- The yt-dlp output template used `%(id)s`, which expands to whatever ID the matched Twitter extractor returns. For `twitter:amplify`, `twitter:broadcast`, or `twitter:card` sub-extractors that can be a media/broadcast ID instead of the tweet status ID — so the downloaded file wouldn't reliably carry the tweet ID in its name.
- Parse the status ID from the tweet URL (`/status/<digits>`) and substitute it literally into the output template. Fall back to `%(id)s` only if the URL doesn't match.

## Filename shape
Unchanged on the surface — still `{date_}{title} [{tweet_id}].{ext}` — but `{tweet_id}` is now guaranteed to be the tweet's status ID whenever the URL contains one.

## Test plan
- [ ] Download a regular tweet video → filename ends with `[<tweet_status_id>].mp4`
- [ ] Download a tweet whose video goes through an amplify/broadcast sub-extractor → filename still ends with the tweet status ID, not the media/broadcast ID
- [ ] Download from a URL without `/status/<id>` (edge case) → falls back to yt-dlp's `%(id)s` and still produces a valid filename