### PR TITLE
feat: automatic image download pipeline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,8 @@ background.js (Service Worker, ES module)
 │   (Windows). Bearer token auth from ~/.xtap/secret             │
 │   Endpoints: GET /status, POST /tweets, /log, /test-path,     │
 │   /check-ytdlp, /download-video, /download-status             │
+│   /tweets accepts image_download:true to opt-in to background │
+│   image fetches; returns images_queued in the response.       │
 └────────────────────────────────────────────────────────────────┘
 ┌─── Native messaging (token bootstrap only) ───────────────────┐
 │ xtap_host.py (Python, stdio)                                   │
@@ -42,6 +44,8 @@ background.js (Service Worker, ES module)
   ▼
 tweets-YYYY-MM-DD.jsonl  (daily rotation)
 debug-YYYY-MM-DD.log     (when debug logging enabled)
+media/<tweet_id>/*       (when image download enabled)
+media-manifest.jsonl     (when image download enabled — append-only download log)
 ```
 
 ### Key Design Decisions
@@ -58,6 +62,7 @@ debug-YYYY-MM-DD.log     (when debug logging enabled)
 - **Path validation:** When the user sets a custom output directory, the service worker sends a `TEST_PATH` request to the HTTP daemon, which attempts `makedirs` + write/delete of a temp file before accepting the path.
 - **Error resilience:** The native host logs crashes to `~/.xtap/host-error.log` with Python version and traceback. The HTTP daemon returns error status codes and logs startup diagnostics (Python version, output dir, token status). When the daemon is unreachable, the extension shows a red "!" badge and buffers tweets until the next successful reprobe (30s cooldown). The popup auto-refreshes every 2 seconds to reflect transport state changes.
 - **Daemon debug logging:** Set `XTAP_LOG_LEVEL=debug` to get per-request logging (method, path, duration, tweet counts, tracebacks). Configured via environment variable in the service template (launchd/systemd). Re-run `install.sh` after changing.
+- **Image download tuning (env vars, all optional):** `XTAP_IMAGE_DELAY_MS` (default 100) sets the inter-request delay for the background image worker. `XTAP_MAX_FILE_MB` (default 50) caps the size of a single image; the worker aborts mid-stream and deletes the `.part` file when exceeded. `XTAP_MAX_MEDIA_MB` (default unset = unlimited) caps the cumulative bytes downloaded per process; further jobs log `skipped:quota`. Bad values fall back to defaults with a stderr warning instead of crashing the daemon.
 
 ## Stealth Constraints
 
@@ -73,6 +78,12 @@ debug-YYYY-MM-DD.log     (when debug logging enabled)
 8. **Only `open()` patched on XHR** — `send()` is not patched, so non-GraphQL XHR calls have clean stack traces.
 
 **Any change that adds network requests to X/Twitter domains must be rejected.**
+
+**Carve-outs (opt-in only, daemon-side, off by default):**
+- **Video download** (`/download-video`) — user-initiated via popup button; calls `pbs.twimg.com` / `video.twimg.com` and runs yt-dlp.
+- **Image download** (`image_download:true` on `/tweets`) — opt-in toggle in popup. The daemon fetches `pbs.twimg.com` photos in a single background worker. Hostname allowlist enforced; redirects blocked; per-file size cap; never enabled by default.
+
+The browser-side capture path stays passive. These carve-outs run on the daemon, not the extension, so the page itself never originates the request.
 
 ## File Structure
 
@@ -163,7 +174,7 @@ Each JSONL line contains:
 }
 ```
 
-Notes: `media[].duration_ms` only present for videos. `views` may be `null`. For retweets, `text` contains the full original tweet text (not the truncated `RT @user:` form). For articles, `is_article` and `article` are present — `article.text` is a markdown rendering with inline `![](media/<id>/file)` image refs, `article.blocks` preserves the raw Draft.js structure, and `article.media[]` lists images with CDN URLs and local paths (assuming `media/<tweet_id>/` layout). Article tweets bypass dedup so the enriched version (from `TweetResultByRestId`) replaces the stub captured from timeline endpoints.
+Notes: `media[].duration_ms` only present for videos. `views` may be `null`. For retweets, `text` contains the full original tweet text (not the truncated `RT @user:` form). For articles, `is_article` and `article` are present — `article.text` is a markdown rendering with inline `![](media/<id>/file)` image refs, `article.blocks` preserves the raw Draft.js structure, and `article.media[]` lists images with CDN URLs and local paths. Article tweets bypass dedup so the enriched version (from `TweetResultByRestId`) replaces the stub captured from timeline endpoints. Top-level `media[]` entries deliberately do NOT carry `local_path` — when image download is enabled, photos land at `media/<tweet_id>/<basename(url)>` by convention. Consumers reconstruct the path; the daemon never round-trips it through the JSONL.
 
 ## Known Issues
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ xTap is a browser extension (Chrome + Firefox) that silently intercepts the Grap
 - **Structured output** — each tweet saved as a clean JSON object with author, metrics, media, and more
 - **Article support** — long-form X articles are captured with full text, inline image references, and Draft.js block structure
 - **Video download** — download videos from tweets using yt-dlp (or direct MP4 fallback) via the extension popup. Requires the HTTP daemon. **Note:** unlike passive capture, video downloads make additional network requests to X and are not stealth.
+- **Image download** — opt-in toggle in the popup ("Download images automatically") fetches photos from `pbs.twimg.com` to `<output_dir>/media/<tweet_id>/<filename>` as you browse. Daemon-side; rate-limited; logs to `media-manifest.jsonl`. **Note:** also not stealth — adds requests to the Twitter CDN.
 - **Pause / resume** — click the extension icon to toggle capture on the fly
 - **Live counter** — badge on the extension icon shows tweets captured this session
 - **Multi-tab aware** — multiple X tabs feed into the same service worker with shared deduplication
@@ -331,6 +332,16 @@ Output is written to daily files (`tweets-YYYY-MM-DD.jsonl`). Each line is a sel
 ```
 
 For regular tweets, `is_article` and `article` are absent. For articles, `text` contains a markdown-style rendering of the article with inline image references pointing to `media/<tweet_id>/`.
+
+### Media file convention
+
+When the "Download images automatically" toggle is on, the daemon writes photos to:
+
+```
+<output_dir>/media/<tweet_id>/<basename(media.url)>
+```
+
+Top-level photo `media[]` entries do **not** carry a `local_path` field — the path is derived by convention so consumers can reconstruct it directly from `tweet.id` + the URL basename. Article media (`tweet.article.media[]`) does include `local_path` because that path is also embedded in the rendered article markdown (`![](media/<id>/file.png)`) so the article body works as a self-contained document. Download status (success / 404 / quota / oversize / blocked) is appended to `<output_dir>/media-manifest.jsonl`.
 
 ## Project Structure
 

--- a/background.js
+++ b/background.js
@@ -16,6 +16,7 @@ let seenIds = new Set();
 let sessionCount = 0;
 let allTimeCount = 0;
 let outputDir = '';
+let imageDownload = false;
 let debugLogging = false;
 let verboseLogging = false;
 let logBuffer = [];
@@ -159,13 +160,14 @@ async function _saveStateImpl() {
 async function restoreState() {
   const [seenStored, stored] = await Promise.all([
     seenIdsStorage().get(['seenIds', 'tweetBuffer']),
-    chrome.storage.local.get(['allTimeCount', 'captureEnabled', 'outputDir', 'debugLogging', 'verboseLogging']),
+    chrome.storage.local.get(['allTimeCount', 'captureEnabled', 'outputDir', 'imageDownload', 'debugLogging', 'verboseLogging']),
   ]);
   if (seenStored.seenIds) seenIds = new Set(seenStored.seenIds.filter(Boolean));
   if (Array.isArray(seenStored.tweetBuffer)) buffer = seenStored.tweetBuffer;
   if (typeof stored.allTimeCount === 'number') allTimeCount = stored.allTimeCount;
   if (typeof stored.captureEnabled === 'boolean') captureEnabled = stored.captureEnabled;
   if (typeof stored.outputDir === 'string') outputDir = stored.outputDir;
+  if (typeof stored.imageDownload === 'boolean') imageDownload = stored.imageDownload;
   if (typeof stored.debugLogging === 'boolean') debugLogging = stored.debugLogging;
   if (typeof stored.verboseLogging === 'boolean') verboseLogging = stored.verboseLogging;
 }
@@ -341,6 +343,7 @@ async function sendToHost(msg) {
     path = '/tweets';
     body = { tweets: msg.tweets };
     if (msg.outputDir) body.outputDir = msg.outputDir;
+    if (msg.imageDownload) body.image_download = true;
   }
 
   try {
@@ -428,6 +431,7 @@ async function flush() {
     const batch = buffer.splice(0);
     const message = { tweets: batch };
     if (outputDir) message.outputDir = outputDir;
+    if (imageDownload) message.imageDownload = true;
 
     try {
       const resp = await sendToHost(message);
@@ -666,6 +670,7 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
         connected: transport !== 'none',
         buffered: buffer.length,
         outputDir,
+        imageDownload,
         debugLogging,
         verboseLogging,
         transport,
@@ -719,6 +724,13 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
       chrome.storage.local.set({ outputDir });
       sendResponse({ outputDir });
     }
+    return true;
+  }
+
+  if (msg.type === 'SET_IMAGE_DOWNLOAD') {
+    imageDownload = !!msg.imageDownload;
+    chrome.storage.local.set({ imageDownload });
+    sendResponse({ imageDownload });
     return true;
   }
 

--- a/manifest.firefox.json
+++ b/manifest.firefox.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "xTap",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "description": "Passively captures tweets from X/Twitter as you browse",
   "permissions": [
     "storage",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "xTap",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "description": "Passively captures tweets from X/Twitter as you browse",
   "permissions": ["storage", "nativeMessaging"],
   "host_permissions": ["*://*.x.com/*", "*://*.twitter.com/*", "http://127.0.0.1/*"],

--- a/native-host/xtap_core.py
+++ b/native-host/xtap_core.py
@@ -422,8 +422,7 @@ def _is_safe_rel_path(out_dir, rel_path):
     candidate = os.path.realpath(os.path.join(out_real, rel_path))
     try:
         return os.path.commonpath([out_real, candidate]) == out_real
-    except ValueError:
-        # Different drives on Windows.
+    except ValueError:  # pragma: no cover — Windows-only: different drives
         return False
 
 
@@ -561,7 +560,7 @@ class ImageDownloader:
         while True:
             try:
                 job, out_dir = self.queue.get()
-            except Exception:
+            except Exception:  # pragma: no cover — only fires at interpreter shutdown
                 continue
             try:
                 self._process(job, out_dir)
@@ -659,7 +658,7 @@ class ImageDownloader:
     def _log(self, out_dir, tweet_id, url, dest_path, status, size):
         try:
             local_path = os.path.relpath(dest_path, out_dir)
-        except ValueError:
+        except ValueError:  # pragma: no cover — Windows-only: different drives
             local_path = dest_path
         entry = {
             'timestamp': datetime.now(timezone.utc).isoformat(),
@@ -684,7 +683,7 @@ def _is_allowed_url(url):
         return False
     try:
         parsed = urlparse(url)
-    except ValueError:
+    except ValueError:  # pragma: no cover — urlparse rarely raises in practice
         return False
     if parsed.scheme != 'https':
         return False

--- a/native-host/xtap_core.py
+++ b/native-host/xtap_core.py
@@ -3,13 +3,17 @@
 import glob
 import json
 import os
+import queue
 import re
 import shutil
 import subprocess
 import sys
 import threading
+import time
+import urllib.error
 import urllib.request
-from datetime import date
+from datetime import date, datetime, timezone
+from urllib.parse import urlparse
 
 
 DEFAULT_OUTPUT_DIR = os.environ.get('XTAP_OUTPUT_DIR', os.path.expanduser('~/Downloads/xtap'))
@@ -349,3 +353,214 @@ def _download_with_ytdlp(download_id, tweet_url, video_dir, post_date=''):  # pr
     with _downloads_lock:
         _downloads[download_id].update(
             progress=100, status='done', path=final_path)
+
+
+# --- Image download ---
+
+# Strip a trailing :orig / :large / :medium etc. suffix Twitter appends to media URLs.
+_TWIMG_SIZE_SUFFIX_RE = re.compile(r':(orig|large|medium|small|thumb)$')
+
+
+def _photo_filename(url):
+    """Extract the CDN filename from a pbs.twimg.com photo URL.
+
+    Returns the basename without any trailing :size suffix, or None if the URL
+    has no usable filename.
+    """
+    if not url:
+        return None
+    cleaned = _TWIMG_SIZE_SUFFIX_RE.sub('', url)
+    path = urlparse(cleaned).path or cleaned
+    name = os.path.basename(path)
+    if not name or name in ('.', '..'):
+        return None
+    # Drop any unexpected path separators just in case
+    return name.replace('/', '_').replace('\\', '_')
+
+
+def inject_image_local_paths(tweets):
+    """Add `local_path` to each photo media item and return a list of pending downloads.
+
+    Mutates tweets in place: every photo media item with a usable URL gets
+    `local_path = "media/<tweet_id>/<cdn_filename>"`. Article media items
+    (under `tweet.article.media[]`) already have `local_path` set by the JS
+    parser, so they are not mutated — just collected for download.
+
+    Returns: list of {tweet_id, url, rel_path} for the caller to enqueue.
+    """
+    pending = []
+    for tweet in tweets:
+        tweet_id = tweet.get('id')
+        if not tweet_id:
+            continue
+
+        # Top-level photo media (regular tweets).
+        for item in tweet.get('media') or []:
+            if not isinstance(item, dict) or item.get('type') != 'photo':
+                continue
+            url = item.get('url')
+            filename = _photo_filename(url)
+            if not filename:
+                continue
+            rel_path = f'media/{tweet_id}/{filename}'
+            item['local_path'] = rel_path
+            pending.append({'tweet_id': tweet_id, 'url': url, 'rel_path': rel_path})
+
+        # Article media (long-form posts) — local_path already set by parser.
+        article = tweet.get('article') or {}
+        for item in article.get('media') or []:
+            if not isinstance(item, dict):
+                continue
+            url = item.get('url')
+            rel_path = item.get('local_path')
+            if not url or not rel_path:
+                continue
+            pending.append({'tweet_id': tweet_id, 'url': url, 'rel_path': rel_path})
+
+    return pending
+
+
+_image_downloader = None
+_image_downloader_lock = threading.Lock()
+
+
+def get_image_downloader():
+    """Lazily construct the singleton ImageDownloader."""
+    global _image_downloader
+    with _image_downloader_lock:
+        if _image_downloader is None:
+            _image_downloader = ImageDownloader()
+        return _image_downloader
+
+
+class ImageDownloader:
+    """Single background-thread image downloader with simple rate limiting.
+
+    - One worker, one queue. Per-job cost is small so a single thread is fine
+      and avoids hammering the CDN.
+    - Idempotent: if the destination file already exists, skip the network call
+      and log status='exists'.
+    - Optional total-bytes quota via XTAP_MAX_MEDIA_MB. When exceeded, new jobs
+      log status='skipped:quota' instead of downloading.
+    - 429 responses trigger exponential backoff (capped). Other HTTP errors
+      and network failures log status='error'.
+    """
+
+    DEFAULT_DELAY_MS = 100
+    USER_AGENT = 'xTap/1.0 (+https://github.com/mkubicek/xTap)'
+    MAX_BACKOFF_S = 30
+    REQUEST_TIMEOUT_S = 30
+
+    def __init__(self):
+        self.queue = queue.Queue()
+        self.delay_s = max(0.0, int(os.environ.get('XTAP_IMAGE_DELAY_MS', self.DEFAULT_DELAY_MS)) / 1000.0)
+        max_mb = os.environ.get('XTAP_MAX_MEDIA_MB', '').strip()
+        self.max_bytes = int(float(max_mb) * 1024 * 1024) if max_mb else None
+        self._bytes_lock = threading.Lock()
+        self.bytes_downloaded = 0
+        self._last_request_at = 0.0
+        self._thread = threading.Thread(target=self._run, daemon=True, name='xtap-image-downloader')
+        self._thread.start()
+
+    def enqueue(self, jobs, out_dir):
+        """Enqueue a batch of pending downloads against the given output dir."""
+        for job in jobs:
+            self.queue.put((job, out_dir))
+
+    def _run(self):
+        while True:
+            try:
+                job, out_dir = self.queue.get()
+            except Exception:
+                continue
+            try:
+                self._process(job, out_dir)
+            except Exception as e:  # pragma: no cover — defensive
+                print(f'[xtap:image] worker exception: {e}', file=sys.stderr)
+            finally:
+                self.queue.task_done()
+
+    def _process(self, job, out_dir):
+        tweet_id = job['tweet_id']
+        url = job['url']
+        rel_path = job['rel_path']
+        dest_path = os.path.join(out_dir, rel_path)
+
+        if os.path.exists(dest_path):
+            self._log(out_dir, tweet_id, url, dest_path, 'exists', os.path.getsize(dest_path))
+            return
+
+        if self.max_bytes is not None:
+            with self._bytes_lock:
+                over_quota = self.bytes_downloaded >= self.max_bytes
+            if over_quota:
+                self._log(out_dir, tweet_id, url, dest_path, 'skipped:quota', 0)
+                return
+
+        # Simple rate limiter: enforce delay_s between requests.
+        if self.delay_s > 0:
+            wait = self.delay_s - (time.monotonic() - self._last_request_at)
+            if wait > 0:
+                time.sleep(wait)
+
+        size, err = self._download(url, dest_path)
+        self._last_request_at = time.monotonic()
+
+        if err:
+            self._log(out_dir, tweet_id, url, dest_path, f'error:{err}', 0)
+            return
+
+        with self._bytes_lock:
+            self.bytes_downloaded += size
+        self._log(out_dir, tweet_id, url, dest_path, 'ok', size)
+
+    def _download(self, url, dest_path):
+        """Download to a .part file and rename atomically. Returns (bytes, error)."""
+        os.makedirs(os.path.dirname(dest_path), exist_ok=True)
+        tmp_path = dest_path + '.part'
+        backoff = 1.0
+        attempts = 0
+        while True:
+            attempts += 1
+            req = urllib.request.Request(url, headers={'User-Agent': self.USER_AGENT})
+            try:
+                with urllib.request.urlopen(req, timeout=self.REQUEST_TIMEOUT_S) as resp:
+                    with open(tmp_path, 'wb') as f:
+                        shutil.copyfileobj(resp, f)
+                size = os.path.getsize(tmp_path)
+                os.replace(tmp_path, dest_path)
+                return size, None
+            except urllib.error.HTTPError as e:
+                _safe_unlink(tmp_path)
+                if e.code == 429 and backoff <= self.MAX_BACKOFF_S and attempts < 4:
+                    time.sleep(backoff)
+                    backoff *= 2
+                    continue
+                return 0, f'http_{e.code}'
+            except (urllib.error.URLError, OSError, TimeoutError) as e:
+                _safe_unlink(tmp_path)
+                return 0, type(e).__name__
+
+    def _log(self, out_dir, tweet_id, url, dest_path, status, size):
+        entry = {
+            'timestamp': datetime.now(timezone.utc).isoformat(),
+            'tweet_id': tweet_id,
+            'url': url,
+            'local_path': os.path.relpath(dest_path, out_dir) if dest_path.startswith(out_dir) else dest_path,
+            'status': status,
+            'bytes': size,
+        }
+        manifest_path = os.path.join(out_dir, 'media-manifest.jsonl')
+        try:
+            os.makedirs(out_dir, exist_ok=True)
+            with open(manifest_path, 'a') as f:
+                f.write(json.dumps(entry, ensure_ascii=False) + '\n')
+        except OSError as e:
+            print(f'[xtap:image] manifest write failed: {e}', file=sys.stderr)
+
+
+def _safe_unlink(path):
+    try:
+        os.unlink(path)
+    except OSError:
+        pass

--- a/native-host/xtap_core.py
+++ b/native-host/xtap_core.py
@@ -358,7 +358,7 @@ def _download_with_ytdlp(download_id, tweet_url, video_dir, post_date=''):  # pr
 # --- Image download ---
 
 # Strip a trailing :orig / :large / :medium etc. suffix Twitter appends to media URLs.
-_TWIMG_SIZE_SUFFIX_RE = re.compile(r':(orig|large|medium|small|thumb)$')
+_TWIMG_SIZE_SUFFIX_RE = re.compile(r':(orig|large|medium|small|thumb|tiny)$')
 
 # Twitter snowflake IDs are numeric; reject anything else to block path traversal.
 _TWEET_ID_RE = re.compile(r'^[0-9]+$')

--- a/native-host/xtap_core.py
+++ b/native-host/xtap_core.py
@@ -360,12 +360,41 @@ def _download_with_ytdlp(download_id, tweet_url, video_dir, post_date=''):  # pr
 # Strip a trailing :orig / :large / :medium etc. suffix Twitter appends to media URLs.
 _TWIMG_SIZE_SUFFIX_RE = re.compile(r':(orig|large|medium|small|thumb)$')
 
+# Twitter snowflake IDs are numeric; reject anything else to block path traversal.
+_TWEET_ID_RE = re.compile(r'^[0-9]+$')
+
+# Only fetch from these CDN hosts. Anything else (including redirects) is rejected.
+ALLOWED_IMAGE_HOSTS = frozenset({'pbs.twimg.com'})
+
+
+def _env_int(name, default):
+    """Parse an int env var, falling back to default on missing/empty/invalid."""
+    raw = (os.environ.get(name) or '').strip()
+    if not raw:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        print(f'[xtap:image] invalid {name}={raw!r}, using {default}', file=sys.stderr)
+        return default
+
+
+def _env_float(name, default):
+    raw = (os.environ.get(name) or '').strip()
+    if not raw:
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        print(f'[xtap:image] invalid {name}={raw!r}, using {default}', file=sys.stderr)
+        return default
+
 
 def _photo_filename(url):
     """Extract the CDN filename from a pbs.twimg.com photo URL.
 
     Returns the basename without any trailing :size suffix, or None if the URL
-    has no usable filename.
+    has no usable filename or contains traversal components.
     """
     if not url:
         return None
@@ -374,24 +403,48 @@ def _photo_filename(url):
     name = os.path.basename(path)
     if not name or name in ('.', '..'):
         return None
-    # Drop any unexpected path separators just in case
-    return name.replace('/', '_').replace('\\', '_')
+    # Reject anything with path separators or that would still resolve to a
+    # parent directory after basename (defense in depth).
+    if '/' in name or '\\' in name or name.startswith('.'):
+        return None
+    return name
 
 
-def inject_image_local_paths(tweets):
+def _is_safe_rel_path(out_dir, rel_path):
+    """Verify joining rel_path with out_dir stays under out_dir.
+
+    Catches absolute paths (`/etc/...`), traversal (`../foo`), and Windows
+    drive-letter paths.
+    """
+    if not rel_path or os.path.isabs(rel_path):
+        return False
+    out_real = os.path.realpath(out_dir)
+    candidate = os.path.realpath(os.path.join(out_real, rel_path))
+    try:
+        return os.path.commonpath([out_real, candidate]) == out_real
+    except ValueError:
+        # Different drives on Windows.
+        return False
+
+
+def inject_image_local_paths(tweets, out_dir):
     """Add `local_path` to each photo media item and return a list of pending downloads.
 
     Mutates tweets in place: every photo media item with a usable URL gets
     `local_path = "media/<tweet_id>/<cdn_filename>"`. Article media items
     (under `tweet.article.media[]`) already have `local_path` set by the JS
-    parser, so they are not mutated — just collected for download.
+    parser; this function validates them but does not overwrite them.
+
+    Path components are validated against `out_dir`: tweet IDs must match
+    [0-9]+, filenames must be plain basenames, and the final resolved path
+    must stay under `out_dir`. Anything that fails validation is skipped.
 
     Returns: list of {tweet_id, url, rel_path} for the caller to enqueue.
     """
     pending = []
     for tweet in tweets:
         tweet_id = tweet.get('id')
-        if not tweet_id:
+        if not tweet_id or not isinstance(tweet_id, str) or not _TWEET_ID_RE.match(tweet_id):
             continue
 
         # Top-level photo media (regular tweets).
@@ -403,17 +456,25 @@ def inject_image_local_paths(tweets):
             if not filename:
                 continue
             rel_path = f'media/{tweet_id}/{filename}'
+            if not _is_safe_rel_path(out_dir, rel_path):
+                continue
             item['local_path'] = rel_path
             pending.append({'tweet_id': tweet_id, 'url': url, 'rel_path': rel_path})
 
-        # Article media (long-form posts) — local_path already set by parser.
+        # Article media (long-form posts) — local_path is set by the JS parser
+        # but we MUST re-validate it here: it crosses the trust boundary in
+        # the request body, so a crafted local_path could escape out_dir.
         article = tweet.get('article') or {}
         for item in article.get('media') or []:
             if not isinstance(item, dict):
                 continue
             url = item.get('url')
             rel_path = item.get('local_path')
-            if not url or not rel_path:
+            if not url or not isinstance(rel_path, str):
+                continue
+            if not _is_safe_rel_path(out_dir, rel_path):
+                # Strip the unsafe path so it doesn't end up in the JSONL.
+                item.pop('local_path', None)
                 continue
             pending.append({'tweet_id': tweet_id, 'url': url, 'rel_path': rel_path})
 
@@ -433,29 +494,52 @@ def get_image_downloader():
         return _image_downloader
 
 
+def reset_image_downloader():
+    """Reset the singleton (test-only — leaks the previous worker thread)."""
+    global _image_downloader
+    with _image_downloader_lock:
+        _image_downloader = None
+
+
+class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Treat any redirect as an error so we never fetch beyond the allowlisted host."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        raise urllib.error.HTTPError(req.full_url, code, f'redirect to {newurl} blocked', headers, fp)
+
+
+_NO_REDIRECT_OPENER = urllib.request.build_opener(_NoRedirectHandler())
+
+
 class ImageDownloader:
-    """Single background-thread image downloader with simple rate limiting.
+    """Single background-thread image downloader with hardened HTTP fetch.
 
     - One worker, one queue. Per-job cost is small so a single thread is fine
       and avoids hammering the CDN.
     - Idempotent: if the destination file already exists, skip the network call
       and log status='exists'.
-    - Optional total-bytes quota via XTAP_MAX_MEDIA_MB. When exceeded, new jobs
-      log status='skipped:quota' instead of downloading.
-    - 429 responses trigger exponential backoff (capped). Other HTTP errors
-      and network failures log status='error'.
+    - URL hostname is checked against ALLOWED_IMAGE_HOSTS before every request.
+      Redirects are blocked entirely (so an attacker can't 302 us off-allowlist).
+    - Per-file size cap (XTAP_MAX_FILE_MB, default 50) bounds disk impact even
+      for adversarial responses. Optional cumulative cap via XTAP_MAX_MEDIA_MB.
+    - 429 responses trigger exponential backoff (capped at MAX_BACKOFF_S).
+      Other HTTP errors and network failures log status='error'.
     """
 
     DEFAULT_DELAY_MS = 100
+    DEFAULT_MAX_FILE_MB = 50
     USER_AGENT = 'xTap/1.0 (+https://github.com/mkubicek/xTap)'
     MAX_BACKOFF_S = 30
     REQUEST_TIMEOUT_S = 30
+    CHUNK_SIZE = 64 * 1024
 
     def __init__(self):
         self.queue = queue.Queue()
-        self.delay_s = max(0.0, int(os.environ.get('XTAP_IMAGE_DELAY_MS', self.DEFAULT_DELAY_MS)) / 1000.0)
-        max_mb = os.environ.get('XTAP_MAX_MEDIA_MB', '').strip()
-        self.max_bytes = int(float(max_mb) * 1024 * 1024) if max_mb else None
+        self.delay_s = max(0.0, _env_int('XTAP_IMAGE_DELAY_MS', self.DEFAULT_DELAY_MS) / 1000.0)
+        max_total_mb = _env_float('XTAP_MAX_MEDIA_MB', 0.0)
+        self.max_bytes = int(max_total_mb * 1024 * 1024) if max_total_mb > 0 else None
+        max_file_mb = _env_float('XTAP_MAX_FILE_MB', float(self.DEFAULT_MAX_FILE_MB))
+        self.max_file_bytes = int(max_file_mb * 1024 * 1024) if max_file_mb > 0 else None
         self._bytes_lock = threading.Lock()
         self.bytes_downloaded = 0
         self._last_request_at = 0.0
@@ -484,10 +568,21 @@ class ImageDownloader:
         tweet_id = job['tweet_id']
         url = job['url']
         rel_path = job['rel_path']
+
+        # Re-validate the rel_path defensively: enqueue() is exported and a
+        # future caller could skip inject_image_local_paths.
+        if not _is_safe_rel_path(out_dir, rel_path):
+            self._log(out_dir, tweet_id, url, rel_path, 'error:unsafe_path', 0)
+            return
+
         dest_path = os.path.join(out_dir, rel_path)
 
         if os.path.exists(dest_path):
             self._log(out_dir, tweet_id, url, dest_path, 'exists', os.path.getsize(dest_path))
+            return
+
+        if not _is_allowed_url(url):
+            self._log(out_dir, tweet_id, url, dest_path, 'error:host_not_allowed', 0)
             return
 
         if self.max_bytes is not None:
@@ -524,9 +619,23 @@ class ImageDownloader:
             attempts += 1
             req = urllib.request.Request(url, headers={'User-Agent': self.USER_AGENT})
             try:
-                with urllib.request.urlopen(req, timeout=self.REQUEST_TIMEOUT_S) as resp:
+                with _NO_REDIRECT_OPENER.open(req, timeout=self.REQUEST_TIMEOUT_S) as resp:
+                    # Reject up-front when Content-Length advertises an oversize body.
+                    if self.max_file_bytes is not None:
+                        cl = resp.headers.get('Content-Length')
+                        if cl and cl.isdigit() and int(cl) > self.max_file_bytes:
+                            return 0, 'too_large'
+                    written = 0
                     with open(tmp_path, 'wb') as f:
-                        shutil.copyfileobj(resp, f)
+                        while True:
+                            chunk = resp.read(self.CHUNK_SIZE)
+                            if not chunk:
+                                break
+                            written += len(chunk)
+                            if self.max_file_bytes is not None and written > self.max_file_bytes:
+                                _safe_unlink(tmp_path)
+                                return 0, 'too_large'
+                            f.write(chunk)
                 size = os.path.getsize(tmp_path)
                 os.replace(tmp_path, dest_path)
                 return size, None
@@ -542,11 +651,15 @@ class ImageDownloader:
                 return 0, type(e).__name__
 
     def _log(self, out_dir, tweet_id, url, dest_path, status, size):
+        try:
+            local_path = os.path.relpath(dest_path, out_dir)
+        except ValueError:
+            local_path = dest_path
         entry = {
             'timestamp': datetime.now(timezone.utc).isoformat(),
             'tweet_id': tweet_id,
             'url': url,
-            'local_path': os.path.relpath(dest_path, out_dir) if dest_path.startswith(out_dir) else dest_path,
+            'local_path': local_path,
             'status': status,
             'bytes': size,
         }
@@ -557,6 +670,20 @@ class ImageDownloader:
                 f.write(json.dumps(entry, ensure_ascii=False) + '\n')
         except OSError as e:
             print(f'[xtap:image] manifest write failed: {e}', file=sys.stderr)
+
+
+def _is_allowed_url(url):
+    """True iff url is https and the hostname is in ALLOWED_IMAGE_HOSTS."""
+    if not url or not isinstance(url, str):
+        return False
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return False
+    if parsed.scheme != 'https':
+        return False
+    host = (parsed.hostname or '').lower()
+    return host in ALLOWED_IMAGE_HOSTS
 
 
 def _safe_unlink(path):

--- a/native-host/xtap_core.py
+++ b/native-host/xtap_core.py
@@ -427,19 +427,27 @@ def _is_safe_rel_path(out_dir, rel_path):
         return False
 
 
-def inject_image_local_paths(tweets, out_dir):
-    """Add `local_path` to each photo media item and return a list of pending downloads.
+def collect_image_jobs(tweets, out_dir):
+    """Compute the list of image download jobs for a batch of tweets.
 
-    Mutates tweets in place: every photo media item with a usable URL gets
-    `local_path = "media/<tweet_id>/<cdn_filename>"`. Article media items
-    (under `tweet.article.media[]`) already have `local_path` set by the JS
-    parser; this function validates them but does not overwrite them.
+    For top-level photo media the rel_path is derived by convention
+    (`media/<tweet_id>/<cdn_filename>`) — the JSONL never carries a
+    redundant `local_path` field for these. Consumers who need the path
+    can reconstruct it from `id` + `basename(url)`.
+
+    Article media items (under `tweet.article.media[]`) already have
+    `local_path` set by the JS parser because that path is also embedded
+    in the article's rendered Markdown text (`![](media/<id>/file.png)`).
+    Those entries are validated here but not mutated; if the supplied
+    `local_path` would escape `out_dir`, the field is stripped so the
+    unsafe path never lands in the JSONL.
 
     Path components are validated against `out_dir`: tweet IDs must match
-    [0-9]+, filenames must be plain basenames, and the final resolved path
-    must stay under `out_dir`. Anything that fails validation is skipped.
+    [0-9]+, filenames must be plain basenames, and the final resolved
+    path must stay under `out_dir`. Anything that fails validation is
+    skipped.
 
-    Returns: list of {tweet_id, url, rel_path} for the caller to enqueue.
+    Returns: list of {tweet_id, url, rel_path} ready for the downloader.
     """
     pending = []
     for tweet in tweets:
@@ -447,7 +455,7 @@ def inject_image_local_paths(tweets, out_dir):
         if not tweet_id or not isinstance(tweet_id, str) or not _TWEET_ID_RE.match(tweet_id):
             continue
 
-        # Top-level photo media (regular tweets).
+        # Top-level photo media (regular tweets) — derived path, no mutation.
         for item in tweet.get('media') or []:
             if not isinstance(item, dict) or item.get('type') != 'photo':
                 continue
@@ -458,12 +466,10 @@ def inject_image_local_paths(tweets, out_dir):
             rel_path = f'media/{tweet_id}/{filename}'
             if not _is_safe_rel_path(out_dir, rel_path):
                 continue
-            item['local_path'] = rel_path
             pending.append({'tweet_id': tweet_id, 'url': url, 'rel_path': rel_path})
 
-        # Article media (long-form posts) — local_path is set by the JS parser
-        # but we MUST re-validate it here: it crosses the trust boundary in
-        # the request body, so a crafted local_path could escape out_dir.
+        # Article media — local_path crosses the trust boundary in the
+        # request body, so re-validate it here.
         article = tweet.get('article') or {}
         for item in article.get('media') or []:
             if not isinstance(item, dict):

--- a/native-host/xtap_daemon.py
+++ b/native-host/xtap_daemon.py
@@ -15,9 +15,10 @@ from http.server import ThreadingHTTPServer, BaseHTTPRequestHandler
 from xtap_core import (DEFAULT_OUTPUT_DIR, load_seen_ids, resolve_output_dir,
                        validate_output_dir, write_tweets, write_log,
                        write_dump, test_path,
-                       check_ytdlp, start_download, get_download_status)
+                       check_ytdlp, start_download, get_download_status,
+                       inject_image_local_paths, get_image_downloader)
 
-VERSION = '0.22.0'
+VERSION = '0.23.0'
 BIND_HOST = '127.0.0.1'
 BIND_PORT = int(os.environ.get('XTAP_DAEMON_PORT', 17381))
 MAX_BODY_SIZE = 10 * 1024 * 1024  # 10 MB
@@ -150,12 +151,21 @@ class DaemonHandler(BaseHTTPRequestHandler):
     def _handle_tweets(self, body):
         try:
             msg_dir = body.get('outputDir', '').strip()
+            image_download = bool(body.get('image_download'))
             with _state_lock:
                 out_dir = resolve_output_dir(msg_dir, DEFAULT_OUTPUT_DIR, _seen_ids, _custom_dirs)
                 tweets = body.get('tweets', [])
+                # Compute local_path for photo media before write so the JSONL
+                # records the planned on-disk location regardless of whether
+                # the user has image download enabled this session.
+                pending_images = inject_image_local_paths(tweets)
                 count, dupes = write_tweets(tweets, out_dir, _seen_ids)
-            log_debug(f'  Tweets: {count} written, {dupes} dupes -> {out_dir}')
-            self._send_json({'ok': True, 'count': count, 'dupes': dupes})
+            queued = 0
+            if image_download and pending_images:
+                get_image_downloader().enqueue(pending_images, out_dir)
+                queued = len(pending_images)
+            log_debug(f'  Tweets: {count} written, {dupes} dupes, {queued} images queued -> {out_dir}')
+            self._send_json({'ok': True, 'count': count, 'dupes': dupes, 'images_queued': queued})
         except ValueError as e:
             self._send_json({'ok': False, 'error': str(e)}, 400)
         except Exception as e:

--- a/native-host/xtap_daemon.py
+++ b/native-host/xtap_daemon.py
@@ -151,17 +151,18 @@ class DaemonHandler(BaseHTTPRequestHandler):
     def _handle_tweets(self, body):
         try:
             msg_dir = body.get('outputDir', '').strip()
-            image_download = bool(body.get('image_download'))
+            # Strict boolean: only `true` enables. Avoids string 'false' / number 1
+            # silently turning the feature on.
+            image_download = body.get('image_download') is True
             with _state_lock:
                 out_dir = resolve_output_dir(msg_dir, DEFAULT_OUTPUT_DIR, _seen_ids, _custom_dirs)
                 tweets = body.get('tweets', [])
-                # Compute local_path for photo media before write so the JSONL
-                # records the planned on-disk location regardless of whether
-                # the user has image download enabled this session.
-                pending_images = inject_image_local_paths(tweets)
+                # Only stamp local_path onto media when we'll actually fetch
+                # the file. Keeps the JSONL clean for users who don't opt in.
+                pending_images = inject_image_local_paths(tweets, out_dir) if image_download else []
                 count, dupes = write_tweets(tweets, out_dir, _seen_ids)
             queued = 0
-            if image_download and pending_images:
+            if pending_images:
                 get_image_downloader().enqueue(pending_images, out_dir)
                 queued = len(pending_images)
             log_debug(f'  Tweets: {count} written, {dupes} dupes, {queued} images queued -> {out_dir}')

--- a/native-host/xtap_daemon.py
+++ b/native-host/xtap_daemon.py
@@ -16,7 +16,7 @@ from xtap_core import (DEFAULT_OUTPUT_DIR, load_seen_ids, resolve_output_dir,
                        validate_output_dir, write_tweets, write_log,
                        write_dump, test_path,
                        check_ytdlp, start_download, get_download_status,
-                       inject_image_local_paths, get_image_downloader)
+                       collect_image_jobs, get_image_downloader)
 
 VERSION = '0.23.0'
 BIND_HOST = '127.0.0.1'
@@ -157,9 +157,10 @@ class DaemonHandler(BaseHTTPRequestHandler):
             with _state_lock:
                 out_dir = resolve_output_dir(msg_dir, DEFAULT_OUTPUT_DIR, _seen_ids, _custom_dirs)
                 tweets = body.get('tweets', [])
-                # Only stamp local_path onto media when we'll actually fetch
-                # the file. Keeps the JSONL clean for users who don't opt in.
-                pending_images = inject_image_local_paths(tweets, out_dir) if image_download else []
+                # Compute jobs only when we'll actually fetch — collect_image_jobs
+                # may strip unsafe article local_paths from the tweets, so we
+                # must call it before write_tweets to keep the JSONL clean.
+                pending_images = collect_image_jobs(tweets, out_dir) if image_download else []
                 count, dupes = write_tweets(tweets, out_dir, _seen_ids)
             queued = 0
             if pending_images:

--- a/popup.css
+++ b/popup.css
@@ -201,6 +201,22 @@ button.paused {
   background: #b91c1c;
 }
 
+.settings-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 10px;
+  font-size: 12px;
+  color: #e7e9ea;
+  cursor: pointer;
+}
+
+.settings-toggle input {
+  width: auto;
+  margin: 0;
+  cursor: pointer;
+}
+
 .debug-link {
   display: block;
   text-align: center;

--- a/popup.html
+++ b/popup.html
@@ -36,6 +36,10 @@
         <input type="text" id="output-dir" placeholder="~/Downloads/xtap" spellcheck="false">
         <button id="save-dir" class="save-btn">Save</button>
       </div>
+      <label class="settings-toggle">
+        <input type="checkbox" id="image-download">
+        <span>Download images automatically</span>
+      </label>
     </div>
     <a id="open-debug" class="debug-link">Debug Dashboard</a>
   </div>

--- a/popup.js
+++ b/popup.js
@@ -5,6 +5,7 @@ const alltimeEl = document.getElementById('alltime-count');
 const toggleBtn = document.getElementById('toggle');
 const outputDirInput = document.getElementById('output-dir');
 const saveDirBtn = document.getElementById('save-dir');
+const imageDownloadCheckbox = document.getElementById('image-download');
 const videoSection = document.getElementById('video-section');
 const videoLabel = document.getElementById('video-label');
 const ytdlpHint = document.getElementById('ytdlp-hint');
@@ -39,6 +40,8 @@ function render(state) {
     outputDirInput.value = state.outputDir;
   }
 
+  imageDownloadCheckbox.checked = !!state.imageDownload;
+
   currentTransport = state.transport;
 }
 
@@ -54,6 +57,13 @@ function refresh() {
 toggleBtn.addEventListener('click', () => {
   chrome.runtime.sendMessage({ type: 'TOGGLE_CAPTURE' }, (response) => {
     if (response) refresh();
+  });
+});
+
+imageDownloadCheckbox.addEventListener('change', () => {
+  chrome.runtime.sendMessage({
+    type: 'SET_IMAGE_DOWNLOAD',
+    imageDownload: imageDownloadCheckbox.checked,
   });
 });
 

--- a/tests/test_xtap_core.py
+++ b/tests/test_xtap_core.py
@@ -593,6 +593,14 @@ class TestPhotoFilename:
             'https://pbs.twimg.com/media/abc.png:large'
         ) == 'abc.png'
 
+    def test_strips_all_known_size_suffixes(self):
+        # All Twitter image size suffixes — leaving any unstripped would put
+        # a colon in the filename, which is illegal on NTFS.
+        for suffix in ('orig', 'large', 'medium', 'small', 'thumb', 'tiny'):
+            assert xtap_core._photo_filename(
+                f'https://pbs.twimg.com/media/abc.jpg:{suffix}'
+            ) == 'abc.jpg', f'failed for :{suffix}'
+
     def test_no_suffix(self):
         assert xtap_core._photo_filename(
             'https://pbs.twimg.com/media/abc.jpg'
@@ -893,6 +901,54 @@ class TestImageDownloader:
         assert not (tmp_path / 'media' / '2' / 'missing.jpg').exists()
         entries = [json.loads(l) for l in (tmp_path / 'media-manifest.jsonl').read_text().splitlines()]
         assert entries[0]['status'] == 'error:http_404'
+
+    def test_429_retries_then_succeeds(self, downloader, tmp_path, monkeypatch):
+        """After two 429s the third attempt succeeds, file lands on disk."""
+        import urllib.error
+        attempts = {'n': 0}
+        body = b'\x89PNGsuccess'
+
+        def fake_open(req, timeout=None):
+            attempts['n'] += 1
+            if attempts['n'] < 3:
+                raise urllib.error.HTTPError(req.full_url, 429, 'Too Many', {}, None)
+            return _FakeResponse(body)
+
+        # Don't actually sleep through the backoff in tests.
+        monkeypatch.setattr(xtap_core.time, 'sleep', lambda s: None)
+        _patch_opener(monkeypatch, fake_open)
+        downloader.enqueue([{
+            'tweet_id': '10',
+            'url': 'https://pbs.twimg.com/media/rate.jpg',
+            'rel_path': 'media/10/rate.jpg',
+        }], str(tmp_path))
+        _wait_for_queue(downloader)
+        assert attempts['n'] == 3
+        assert (tmp_path / 'media' / '10' / 'rate.jpg').read_bytes() == body
+        entries = [json.loads(l) for l in (tmp_path / 'media-manifest.jsonl').read_text().splitlines()]
+        assert entries[0]['status'] == 'ok'
+
+    def test_429_gives_up_after_max_attempts(self, downloader, tmp_path, monkeypatch):
+        """Persistent 429 returns error:http_429 after attempt 4."""
+        import urllib.error
+        attempts = {'n': 0}
+
+        def fake_open(req, timeout=None):
+            attempts['n'] += 1
+            raise urllib.error.HTTPError(req.full_url, 429, 'Too Many', {}, None)
+
+        monkeypatch.setattr(xtap_core.time, 'sleep', lambda s: None)
+        _patch_opener(monkeypatch, fake_open)
+        downloader.enqueue([{
+            'tweet_id': '11',
+            'url': 'https://pbs.twimg.com/media/rate.jpg',
+            'rel_path': 'media/11/rate.jpg',
+        }], str(tmp_path))
+        _wait_for_queue(downloader)
+        # 3 retries (attempts < 4 in source) means 4 total tries.
+        assert attempts['n'] == 4
+        entries = [json.loads(l) for l in (tmp_path / 'media-manifest.jsonl').read_text().splitlines()]
+        assert entries[0]['status'] == 'error:http_429'
 
     def test_quota_skips(self, downloader, tmp_path, monkeypatch):
         # Pre-set bytes_downloaded above the cap so the next job hits 'skipped:quota'.

--- a/tests/test_xtap_core.py
+++ b/tests/test_xtap_core.py
@@ -733,6 +733,26 @@ class TestCollectImageJobs:
         assert pending == []
         assert 'local_path' not in tweets[0]['media'][0]
 
+    def test_top_level_photo_unsafe_rel_path_skipped(self, tmp_path, monkeypatch):
+        # Force _is_safe_rel_path to reject so we exercise the top-level skip
+        # branch (it is otherwise unreachable because tweet_id and filename
+        # are validated upstream).
+        monkeypatch.setattr(xtap_core, '_is_safe_rel_path', lambda _o, _r: False)
+        tweets = [{
+            'id': '123',
+            'media': [{'type': 'photo', 'url': 'https://pbs.twimg.com/media/abc.jpg'}],
+        }]
+        pending = xtap_core.collect_image_jobs(tweets, str(tmp_path))
+        assert pending == []
+
+    def test_skips_non_dict_article_media_item(self, tmp_path):
+        tweets = [{
+            'id': '999',
+            'article': {'media': ['not-a-dict', 42, None]},
+        }]
+        # Must not raise on non-dict items.
+        assert xtap_core.collect_image_jobs(tweets, str(tmp_path)) == []
+
 
 class TestPhotoFilenameHardening:
     def test_basename_strip_traversal(self):
@@ -1066,6 +1086,50 @@ class TestImageDownloader:
         req = urllib.request.Request('https://pbs.twimg.com/media/x.jpg')
         with pytest.raises(urllib.error.HTTPError):
             h.redirect_request(req, None, 302, 'Found', {}, 'https://evil.example.com/x.jpg')
+
+
+class TestImageDownloaderRateLimit:
+    def test_sleeps_to_enforce_inter_request_delay(self, tmp_path, monkeypatch):
+        monkeypatch.setenv('XTAP_IMAGE_DELAY_MS', '50')
+        xtap_core.reset_image_downloader()
+        dl = xtap_core.ImageDownloader()
+        sleeps = []
+        # Pretend we just made a request right now so the next job has to wait.
+        dl._last_request_at = 1000.0
+        monkeypatch.setattr(xtap_core.time, 'monotonic', lambda: 1000.0)
+        monkeypatch.setattr(xtap_core.time, 'sleep', lambda s: sleeps.append(s))
+        _patch_opener(monkeypatch, lambda *a, **kw: _FakeResponse(b'x'))
+        dl.enqueue([{
+            'tweet_id': '20',
+            'url': 'https://pbs.twimg.com/media/r.jpg',
+            'rel_path': 'media/20/r.jpg',
+        }], str(tmp_path))
+        _wait_for_queue(dl)
+        # The worker should have called time.sleep with ~delay_s seconds.
+        assert any(s > 0 for s in sleeps), f'expected positive sleep, got {sleeps}'
+
+
+class TestImageDownloaderManifest:
+    def test_manifest_write_oserror_swallowed(self, downloader, tmp_path, monkeypatch, capsys):
+        # Simulate a failing manifest write: open() raises PermissionError.
+        real_open = open
+
+        def fake_open(path, *args, **kwargs):
+            if str(path).endswith('media-manifest.jsonl'):
+                raise PermissionError('read-only filesystem')
+            return real_open(path, *args, **kwargs)
+
+        monkeypatch.setattr('builtins.open', fake_open)
+        _patch_opener(monkeypatch, lambda *a, **kw: _FakeResponse(b'data'))
+        downloader.enqueue([{
+            'tweet_id': '21',
+            'url': 'https://pbs.twimg.com/media/m.jpg',
+            'rel_path': 'media/21/m.jpg',
+        }], str(tmp_path))
+        _wait_for_queue(downloader)
+        # Must not crash the worker. Stderr captures the warning line.
+        captured = capsys.readouterr()
+        assert 'manifest write failed' in captured.err
 
 
 class TestImageDownloaderSingleton:

--- a/tests/test_xtap_core.py
+++ b/tests/test_xtap_core.py
@@ -578,7 +578,7 @@ class TestYtdlpProgressMerger:
 
 
 # ---------------------------------------------------------------------------
-# _photo_filename / inject_image_local_paths
+# _photo_filename / collect_image_jobs
 # ---------------------------------------------------------------------------
 
 
@@ -606,16 +606,18 @@ class TestPhotoFilename:
         assert xtap_core._photo_filename('https://pbs.twimg.com/') is None
 
 
-class TestInjectImageLocalPaths:
-    def test_adds_local_path_to_photos(self, tmp_path):
+class TestCollectImageJobs:
+    def test_returns_jobs_for_photos_without_mutating_jsonl(self, tmp_path):
         tweets = [{
             'id': '123',
             'media': [
                 {'type': 'photo', 'url': 'https://pbs.twimg.com/media/abc.jpg:orig'},
             ],
         }]
-        pending = xtap_core.inject_image_local_paths(tweets, str(tmp_path))
-        assert tweets[0]['media'][0]['local_path'] == 'media/123/abc.jpg'
+        pending = xtap_core.collect_image_jobs(tweets, str(tmp_path))
+        # Top-level photo media is NOT mutated — the path is convention-derived
+        # and consumers can reconstruct it from id + basename(url).
+        assert 'local_path' not in tweets[0]['media'][0]
         assert pending == [{
             'tweet_id': '123',
             'url': 'https://pbs.twimg.com/media/abc.jpg:orig',
@@ -629,18 +631,18 @@ class TestInjectImageLocalPaths:
                 {'type': 'video', 'url': 'https://video.twimg.com/foo.mp4'},
             ],
         }]
-        pending = xtap_core.inject_image_local_paths(tweets, str(tmp_path))
+        pending = xtap_core.collect_image_jobs(tweets, str(tmp_path))
         assert pending == []
         assert 'local_path' not in tweets[0]['media'][0]
 
     def test_skips_tweet_without_id(self, tmp_path):
         tweets = [{'media': [{'type': 'photo', 'url': 'https://pbs.twimg.com/media/x.jpg'}]}]
-        pending = xtap_core.inject_image_local_paths(tweets, str(tmp_path))
+        pending = xtap_core.collect_image_jobs(tweets, str(tmp_path))
         assert pending == []
 
     def test_handles_missing_media(self, tmp_path):
         tweets = [{'id': '123'}, {'id': '456', 'media': []}]
-        assert xtap_core.inject_image_local_paths(tweets, str(tmp_path)) == []
+        assert xtap_core.collect_image_jobs(tweets, str(tmp_path)) == []
 
     def test_enqueues_article_media(self, tmp_path):
         tweets = [{
@@ -660,7 +662,7 @@ class TestInjectImageLocalPaths:
                 ],
             },
         }]
-        pending = xtap_core.inject_image_local_paths(tweets, str(tmp_path))
+        pending = xtap_core.collect_image_jobs(tweets, str(tmp_path))
         assert [p['rel_path'] for p in pending] == [
             'media/999/HGxr957a0AAzHOk.jpg',
             'media/999/HGxr2u5a8AANAOy.jpg',
@@ -671,11 +673,11 @@ class TestInjectImageLocalPaths:
             'id': '999',
             'article': {'media': [{'url': 'https://pbs.twimg.com/media/x.jpg'}]},
         }]
-        assert xtap_core.inject_image_local_paths(tweets, str(tmp_path)) == []
+        assert xtap_core.collect_image_jobs(tweets, str(tmp_path)) == []
 
     def test_skips_photo_without_url(self, tmp_path):
         tweets = [{'id': '123', 'media': [{'type': 'photo', 'url': None}]}]
-        pending = xtap_core.inject_image_local_paths(tweets, str(tmp_path))
+        pending = xtap_core.collect_image_jobs(tweets, str(tmp_path))
         assert pending == []
         assert 'local_path' not in tweets[0]['media'][0]
 
@@ -684,7 +686,7 @@ class TestInjectImageLocalPaths:
             'id': '../../etc',
             'media': [{'type': 'photo', 'url': 'https://pbs.twimg.com/media/x.jpg'}],
         }]
-        pending = xtap_core.inject_image_local_paths(tweets, str(tmp_path))
+        pending = xtap_core.collect_image_jobs(tweets, str(tmp_path))
         assert pending == []
         assert 'local_path' not in tweets[0]['media'][0]
 
@@ -696,7 +698,7 @@ class TestInjectImageLocalPaths:
                 'local_path': '../../../../etc/passwd',
             }]},
         }]
-        pending = xtap_core.inject_image_local_paths(tweets, str(tmp_path))
+        pending = xtap_core.collect_image_jobs(tweets, str(tmp_path))
         assert pending == []
         # Unsafe local_path is stripped so the JSONL doesn't carry it.
         assert 'local_path' not in tweets[0]['article']['media'][0]
@@ -709,7 +711,7 @@ class TestInjectImageLocalPaths:
                 'local_path': '/etc/passwd',
             }]},
         }]
-        pending = xtap_core.inject_image_local_paths(tweets, str(tmp_path))
+        pending = xtap_core.collect_image_jobs(tweets, str(tmp_path))
         assert pending == []
         assert 'local_path' not in tweets[0]['article']['media'][0]
 
@@ -719,7 +721,7 @@ class TestInjectImageLocalPaths:
             'id': '123',
             'media': [{'type': 'photo', 'url': 'https://pbs.twimg.com/media/..'}],
         }]
-        pending = xtap_core.inject_image_local_paths(tweets, str(tmp_path))
+        pending = xtap_core.collect_image_jobs(tweets, str(tmp_path))
         assert pending == []
         assert 'local_path' not in tweets[0]['media'][0]
 
@@ -952,7 +954,7 @@ class TestImageDownloader:
     def test_rejects_unsafe_rel_path_at_worker(self, downloader, tmp_path, monkeypatch):
         called = []
         _patch_opener(monkeypatch, lambda *a, **kw: called.append(1) or _FakeResponse(b''))
-        # Even if a future caller skips inject_image_local_paths, the worker
+        # Even if a future caller skips collect_image_jobs, the worker
         # rejects an unsafe rel_path before any FS or network work.
         downloader.enqueue([{
             'tweet_id': '7',

--- a/tests/test_xtap_core.py
+++ b/tests/test_xtap_core.py
@@ -607,14 +607,14 @@ class TestPhotoFilename:
 
 
 class TestInjectImageLocalPaths:
-    def test_adds_local_path_to_photos(self):
+    def test_adds_local_path_to_photos(self, tmp_path):
         tweets = [{
             'id': '123',
             'media': [
                 {'type': 'photo', 'url': 'https://pbs.twimg.com/media/abc.jpg:orig'},
             ],
         }]
-        pending = xtap_core.inject_image_local_paths(tweets)
+        pending = xtap_core.inject_image_local_paths(tweets, str(tmp_path))
         assert tweets[0]['media'][0]['local_path'] == 'media/123/abc.jpg'
         assert pending == [{
             'tweet_id': '123',
@@ -622,27 +622,27 @@ class TestInjectImageLocalPaths:
             'rel_path': 'media/123/abc.jpg',
         }]
 
-    def test_skips_video_media(self):
+    def test_skips_video_media(self, tmp_path):
         tweets = [{
             'id': '123',
             'media': [
                 {'type': 'video', 'url': 'https://video.twimg.com/foo.mp4'},
             ],
         }]
-        pending = xtap_core.inject_image_local_paths(tweets)
+        pending = xtap_core.inject_image_local_paths(tweets, str(tmp_path))
         assert pending == []
         assert 'local_path' not in tweets[0]['media'][0]
 
-    def test_skips_tweet_without_id(self):
+    def test_skips_tweet_without_id(self, tmp_path):
         tweets = [{'media': [{'type': 'photo', 'url': 'https://pbs.twimg.com/media/x.jpg'}]}]
-        pending = xtap_core.inject_image_local_paths(tweets)
+        pending = xtap_core.inject_image_local_paths(tweets, str(tmp_path))
         assert pending == []
 
-    def test_handles_missing_media(self):
+    def test_handles_missing_media(self, tmp_path):
         tweets = [{'id': '123'}, {'id': '456', 'media': []}]
-        assert xtap_core.inject_image_local_paths(tweets) == []
+        assert xtap_core.inject_image_local_paths(tweets, str(tmp_path)) == []
 
-    def test_enqueues_article_media(self):
+    def test_enqueues_article_media(self, tmp_path):
         tweets = [{
             'id': '999',
             'media': [],
@@ -660,24 +660,125 @@ class TestInjectImageLocalPaths:
                 ],
             },
         }]
-        pending = xtap_core.inject_image_local_paths(tweets)
+        pending = xtap_core.inject_image_local_paths(tweets, str(tmp_path))
         assert [p['rel_path'] for p in pending] == [
             'media/999/HGxr957a0AAzHOk.jpg',
             'media/999/HGxr2u5a8AANAOy.jpg',
         ]
 
-    def test_skips_article_media_without_local_path(self):
+    def test_skips_article_media_without_local_path(self, tmp_path):
         tweets = [{
             'id': '999',
             'article': {'media': [{'url': 'https://pbs.twimg.com/media/x.jpg'}]},
         }]
-        assert xtap_core.inject_image_local_paths(tweets) == []
+        assert xtap_core.inject_image_local_paths(tweets, str(tmp_path)) == []
 
-    def test_skips_photo_without_url(self):
+    def test_skips_photo_without_url(self, tmp_path):
         tweets = [{'id': '123', 'media': [{'type': 'photo', 'url': None}]}]
-        pending = xtap_core.inject_image_local_paths(tweets)
+        pending = xtap_core.inject_image_local_paths(tweets, str(tmp_path))
         assert pending == []
         assert 'local_path' not in tweets[0]['media'][0]
+
+    def test_rejects_non_numeric_tweet_id(self, tmp_path):
+        tweets = [{
+            'id': '../../etc',
+            'media': [{'type': 'photo', 'url': 'https://pbs.twimg.com/media/x.jpg'}],
+        }]
+        pending = xtap_core.inject_image_local_paths(tweets, str(tmp_path))
+        assert pending == []
+        assert 'local_path' not in tweets[0]['media'][0]
+
+    def test_rejects_article_local_path_with_traversal(self, tmp_path):
+        tweets = [{
+            'id': '999',
+            'article': {'media': [{
+                'url': 'https://pbs.twimg.com/media/x.jpg',
+                'local_path': '../../../../etc/passwd',
+            }]},
+        }]
+        pending = xtap_core.inject_image_local_paths(tweets, str(tmp_path))
+        assert pending == []
+        # Unsafe local_path is stripped so the JSONL doesn't carry it.
+        assert 'local_path' not in tweets[0]['article']['media'][0]
+
+    def test_rejects_article_local_path_absolute(self, tmp_path):
+        tweets = [{
+            'id': '999',
+            'article': {'media': [{
+                'url': 'https://pbs.twimg.com/media/x.jpg',
+                'local_path': '/etc/passwd',
+            }]},
+        }]
+        pending = xtap_core.inject_image_local_paths(tweets, str(tmp_path))
+        assert pending == []
+        assert 'local_path' not in tweets[0]['article']['media'][0]
+
+    def test_rejects_photo_filename_with_traversal_basename(self, tmp_path):
+        # Forged URL whose basename is ".."
+        tweets = [{
+            'id': '123',
+            'media': [{'type': 'photo', 'url': 'https://pbs.twimg.com/media/..'}],
+        }]
+        pending = xtap_core.inject_image_local_paths(tweets, str(tmp_path))
+        assert pending == []
+        assert 'local_path' not in tweets[0]['media'][0]
+
+
+class TestPhotoFilenameHardening:
+    def test_basename_strip_traversal(self):
+        # urlparse + basename collapses path segments, but our explicit
+        # regex/blocklist must still reject these for defense in depth.
+        assert xtap_core._photo_filename('https://pbs.twimg.com/media/..') is None
+        assert xtap_core._photo_filename('https://pbs.twimg.com/media/.') is None
+        assert xtap_core._photo_filename('https://pbs.twimg.com/.hidden.jpg') is None
+
+    def test_safe_rel_path_blocks_absolute(self, tmp_path):
+        assert xtap_core._is_safe_rel_path(str(tmp_path), '/etc/passwd') is False
+
+    def test_safe_rel_path_blocks_traversal(self, tmp_path):
+        assert xtap_core._is_safe_rel_path(str(tmp_path), '../../etc/passwd') is False
+
+    def test_safe_rel_path_allows_normal(self, tmp_path):
+        assert xtap_core._is_safe_rel_path(str(tmp_path), 'media/123/abc.jpg') is True
+
+
+class TestUrlAllowlist:
+    def test_allows_pbs_twimg(self):
+        assert xtap_core._is_allowed_url('https://pbs.twimg.com/media/x.jpg') is True
+
+    def test_blocks_other_host(self):
+        assert xtap_core._is_allowed_url('https://evil.example.com/x.jpg') is False
+
+    def test_blocks_http_scheme(self):
+        assert xtap_core._is_allowed_url('http://pbs.twimg.com/media/x.jpg') is False
+
+    def test_blocks_file_scheme(self):
+        assert xtap_core._is_allowed_url('file:///etc/passwd') is False
+
+    def test_blocks_metadata_ip(self):
+        assert xtap_core._is_allowed_url('http://169.254.169.254/latest/meta-data/') is False
+
+    def test_blocks_none_or_empty(self):
+        assert xtap_core._is_allowed_url(None) is False
+        assert xtap_core._is_allowed_url('') is False
+
+
+class TestEnvParsing:
+    def test_env_int_falls_back_on_garbage(self, monkeypatch):
+        monkeypatch.setenv('XTAP_IMAGE_DELAY_MS', 'foo')
+        assert xtap_core._env_int('XTAP_IMAGE_DELAY_MS', 100) == 100
+
+    def test_env_int_uses_value_when_valid(self, monkeypatch):
+        monkeypatch.setenv('XTAP_IMAGE_DELAY_MS', '250')
+        assert xtap_core._env_int('XTAP_IMAGE_DELAY_MS', 100) == 250
+
+    def test_env_int_falls_back_on_empty(self, monkeypatch):
+        monkeypatch.setenv('XTAP_IMAGE_DELAY_MS', '')
+        assert xtap_core._env_int('XTAP_IMAGE_DELAY_MS', 100) == 100
+
+    def test_env_float_falls_back_on_garbage(self, monkeypatch):
+        monkeypatch.setenv('XTAP_MAX_FILE_MB', 'big')
+        assert xtap_core._env_float('XTAP_MAX_FILE_MB', 50.0) == 50.0
 
 
 # ---------------------------------------------------------------------------
@@ -686,9 +787,12 @@ class TestInjectImageLocalPaths:
 
 
 class _FakeResponse:
-    def __init__(self, body):
+    def __init__(self, body, content_length=None):
         import io
         self._buf = io.BytesIO(body)
+        self.headers = {}
+        if content_length is not None:
+            self.headers['Content-Length'] = str(content_length)
 
     def read(self, n=-1):
         return self._buf.read(n)
@@ -709,11 +813,21 @@ def _wait_for_queue(downloader, timeout=5):
         __import__('time').sleep(0.02)
 
 
+def _patch_opener(monkeypatch, fake_open):
+    """Replace the download opener with a fake. fake_open(req, timeout=) -> response."""
+    class _FakeOpener:
+        def open(self, req, timeout=None):
+            return fake_open(req, timeout=timeout)
+    monkeypatch.setattr(xtap_core, '_NO_REDIRECT_OPENER', _FakeOpener())
+
+
 @pytest.fixture
 def downloader(monkeypatch):
-    """A fresh ImageDownloader with no rate-limit delay."""
+    """A fresh ImageDownloader with no rate-limit delay and no singleton state."""
     monkeypatch.setenv('XTAP_IMAGE_DELAY_MS', '0')
     monkeypatch.delenv('XTAP_MAX_MEDIA_MB', raising=False)
+    monkeypatch.delenv('XTAP_MAX_FILE_MB', raising=False)
+    xtap_core.reset_image_downloader()
     return xtap_core.ImageDownloader()
 
 
@@ -722,11 +836,11 @@ class TestImageDownloader:
         body = b'\x89PNG\r\n' + b'x' * 100
         opens = []
 
-        def fake_urlopen(req, timeout=None):
+        def fake_open(req, timeout=None):
             opens.append(req.full_url)
             return _FakeResponse(body)
 
-        monkeypatch.setattr(xtap_core.urllib.request, 'urlopen', fake_urlopen)
+        _patch_opener(monkeypatch, fake_open)
         downloader.enqueue([{
             'tweet_id': '1',
             'url': 'https://pbs.twimg.com/media/abc.jpg:orig',
@@ -736,7 +850,6 @@ class TestImageDownloader:
         dest = tmp_path / 'media' / '1' / 'abc.jpg'
         assert dest.read_bytes() == body
         assert opens == ['https://pbs.twimg.com/media/abc.jpg:orig']
-        # Manifest written
         entries = [json.loads(l) for l in (tmp_path / 'media-manifest.jsonl').read_text().splitlines()]
         assert entries[0]['status'] == 'ok'
         assert entries[0]['bytes'] == len(body)
@@ -748,11 +861,11 @@ class TestImageDownloader:
         (dest_dir / 'abc.jpg').write_bytes(b'cached-bytes')
 
         called = []
-        def fake_urlopen(req, timeout=None):
+        def fake_open(req, timeout=None):
             called.append(req.full_url)
             return _FakeResponse(b'should-not-run')
 
-        monkeypatch.setattr(xtap_core.urllib.request, 'urlopen', fake_urlopen)
+        _patch_opener(monkeypatch, fake_open)
         downloader.enqueue([{
             'tweet_id': '1',
             'url': 'https://pbs.twimg.com/media/abc.jpg:orig',
@@ -766,9 +879,9 @@ class TestImageDownloader:
 
     def test_404_logs_error(self, downloader, tmp_path, monkeypatch):
         import urllib.error
-        def fake_urlopen(req, timeout=None):
+        def fake_open(req, timeout=None):
             raise urllib.error.HTTPError(req.full_url, 404, 'Not Found', {}, None)
-        monkeypatch.setattr(xtap_core.urllib.request, 'urlopen', fake_urlopen)
+        _patch_opener(monkeypatch, fake_open)
         downloader.enqueue([{
             'tweet_id': '2',
             'url': 'https://pbs.twimg.com/media/missing.jpg:orig',
@@ -779,36 +892,128 @@ class TestImageDownloader:
         entries = [json.loads(l) for l in (tmp_path / 'media-manifest.jsonl').read_text().splitlines()]
         assert entries[0]['status'] == 'error:http_404'
 
-    def test_quota_skips(self, tmp_path, monkeypatch):
-        # 0 MB quota — every job should be skipped.
-        monkeypatch.setenv('XTAP_IMAGE_DELAY_MS', '0')
-        monkeypatch.setenv('XTAP_MAX_MEDIA_MB', '0')
-        dl = xtap_core.ImageDownloader()
+    def test_quota_skips(self, downloader, tmp_path, monkeypatch):
+        # Pre-set bytes_downloaded above the cap so the next job hits 'skipped:quota'.
+        downloader.max_bytes = 100
+        downloader.bytes_downloaded = 200
         called = []
-        monkeypatch.setattr(xtap_core.urllib.request, 'urlopen',
-                            lambda *a, **kw: called.append(1) or _FakeResponse(b''))
-        dl.enqueue([{
+        _patch_opener(monkeypatch, lambda *a, **kw: called.append(1) or _FakeResponse(b''))
+        downloader.enqueue([{
             'tweet_id': '3',
             'url': 'https://pbs.twimg.com/media/q.jpg',
             'rel_path': 'media/3/q.jpg',
         }], str(tmp_path))
-        _wait_for_queue(dl)
+        _wait_for_queue(downloader)
         assert called == []
         entries = [json.loads(l) for l in (tmp_path / 'media-manifest.jsonl').read_text().splitlines()]
         assert entries[0]['status'] == 'skipped:quota'
 
     def test_atomic_partial_cleanup_on_error(self, downloader, tmp_path, monkeypatch):
         import urllib.error
-        def fake_urlopen(req, timeout=None):
+        def fake_open(req, timeout=None):
             raise urllib.error.URLError('connection refused')
-        monkeypatch.setattr(xtap_core.urllib.request, 'urlopen', fake_urlopen)
+        _patch_opener(monkeypatch, fake_open)
         downloader.enqueue([{
             'tweet_id': '4',
             'url': 'https://pbs.twimg.com/media/x.jpg',
             'rel_path': 'media/4/x.jpg',
         }], str(tmp_path))
         _wait_for_queue(downloader)
-        # Neither final nor .part should remain.
         media_dir = tmp_path / 'media' / '4'
         if media_dir.exists():
             assert list(media_dir.iterdir()) == []
+
+    def test_blocks_non_allowlisted_host(self, downloader, tmp_path, monkeypatch):
+        called = []
+        _patch_opener(monkeypatch, lambda *a, **kw: called.append(1) or _FakeResponse(b''))
+        downloader.enqueue([{
+            'tweet_id': '5',
+            'url': 'https://evil.example.com/x.jpg',
+            'rel_path': 'media/5/x.jpg',
+        }], str(tmp_path))
+        _wait_for_queue(downloader)
+        assert called == []
+        entries = [json.loads(l) for l in (tmp_path / 'media-manifest.jsonl').read_text().splitlines()]
+        assert entries[0]['status'] == 'error:host_not_allowed'
+
+    def test_blocks_metadata_ip(self, downloader, tmp_path, monkeypatch):
+        called = []
+        _patch_opener(monkeypatch, lambda *a, **kw: called.append(1) or _FakeResponse(b''))
+        downloader.enqueue([{
+            'tweet_id': '6',
+            'url': 'http://169.254.169.254/latest/meta-data/',
+            'rel_path': 'media/6/meta',
+        }], str(tmp_path))
+        _wait_for_queue(downloader)
+        assert called == []
+        entries = [json.loads(l) for l in (tmp_path / 'media-manifest.jsonl').read_text().splitlines()]
+        assert entries[0]['status'] == 'error:host_not_allowed'
+
+    def test_rejects_unsafe_rel_path_at_worker(self, downloader, tmp_path, monkeypatch):
+        called = []
+        _patch_opener(monkeypatch, lambda *a, **kw: called.append(1) or _FakeResponse(b''))
+        # Even if a future caller skips inject_image_local_paths, the worker
+        # rejects an unsafe rel_path before any FS or network work.
+        downloader.enqueue([{
+            'tweet_id': '7',
+            'url': 'https://pbs.twimg.com/media/x.jpg',
+            'rel_path': '../../etc/passwd',
+        }], str(tmp_path))
+        _wait_for_queue(downloader)
+        assert called == []
+        entries = [json.loads(l) for l in (tmp_path / 'media-manifest.jsonl').read_text().splitlines()]
+        assert entries[0]['status'] == 'error:unsafe_path'
+        # Nothing was created outside out_dir.
+        assert not (tmp_path / '..' / 'etc').exists()
+
+    def test_aborts_oversize_response(self, tmp_path, monkeypatch):
+        monkeypatch.setenv('XTAP_IMAGE_DELAY_MS', '0')
+        monkeypatch.setenv('XTAP_MAX_FILE_MB', '0.0001')  # ~104 bytes
+        xtap_core.reset_image_downloader()
+        dl = xtap_core.ImageDownloader()
+        big = b'x' * 5000
+        _patch_opener(monkeypatch, lambda *a, **kw: _FakeResponse(big))
+        dl.enqueue([{
+            'tweet_id': '8',
+            'url': 'https://pbs.twimg.com/media/big.jpg',
+            'rel_path': 'media/8/big.jpg',
+        }], str(tmp_path))
+        _wait_for_queue(dl)
+        assert not (tmp_path / 'media' / '8' / 'big.jpg').exists()
+        assert not (tmp_path / 'media' / '8' / 'big.jpg.part').exists()
+        entries = [json.loads(l) for l in (tmp_path / 'media-manifest.jsonl').read_text().splitlines()]
+        assert entries[0]['status'] == 'error:too_large'
+
+    def test_rejects_oversize_via_content_length(self, tmp_path, monkeypatch):
+        monkeypatch.setenv('XTAP_IMAGE_DELAY_MS', '0')
+        monkeypatch.setenv('XTAP_MAX_FILE_MB', '0.0001')
+        xtap_core.reset_image_downloader()
+        dl = xtap_core.ImageDownloader()
+        # Server claims a huge body up-front — we reject without reading it.
+        _patch_opener(monkeypatch, lambda *a, **kw: _FakeResponse(b'', content_length=10_000_000))
+        dl.enqueue([{
+            'tweet_id': '9',
+            'url': 'https://pbs.twimg.com/media/huge.jpg',
+            'rel_path': 'media/9/huge.jpg',
+        }], str(tmp_path))
+        _wait_for_queue(dl)
+        entries = [json.loads(l) for l in (tmp_path / 'media-manifest.jsonl').read_text().splitlines()]
+        assert entries[0]['status'] == 'error:too_large'
+
+    def test_redirect_handler_raises_for_redirect(self, monkeypatch):
+        """The custom HTTPRedirectHandler must turn redirects into errors."""
+        import urllib.error
+        h = xtap_core._NoRedirectHandler()
+        # Build a fake request and assert HTTPError is raised on redirect attempt.
+        req = urllib.request.Request('https://pbs.twimg.com/media/x.jpg')
+        with pytest.raises(urllib.error.HTTPError):
+            h.redirect_request(req, None, 302, 'Found', {}, 'https://evil.example.com/x.jpg')
+
+
+class TestImageDownloaderSingleton:
+    def test_get_returns_same_instance(self, monkeypatch):
+        xtap_core.reset_image_downloader()
+        a = xtap_core.get_image_downloader()
+        b = xtap_core.get_image_downloader()
+        assert a is b
+        xtap_core.reset_image_downloader()

--- a/tests/test_xtap_core.py
+++ b/tests/test_xtap_core.py
@@ -3,6 +3,7 @@
 import json
 import os
 import sys
+import threading
 
 import pytest
 
@@ -574,3 +575,240 @@ class TestYtdlpProgressMerger:
             '[Merger] Merging formats into "/tmp/final.mp4"',
         ])
         assert t.final_path == '/tmp/final.mp4'
+
+
+# ---------------------------------------------------------------------------
+# _photo_filename / inject_image_local_paths
+# ---------------------------------------------------------------------------
+
+
+class TestPhotoFilename:
+    def test_strips_orig_suffix(self):
+        assert xtap_core._photo_filename(
+            'https://pbs.twimg.com/media/HGK3a3qbAAADTqD.jpg:orig'
+        ) == 'HGK3a3qbAAADTqD.jpg'
+
+    def test_strips_large_suffix(self):
+        assert xtap_core._photo_filename(
+            'https://pbs.twimg.com/media/abc.png:large'
+        ) == 'abc.png'
+
+    def test_no_suffix(self):
+        assert xtap_core._photo_filename(
+            'https://pbs.twimg.com/media/abc.jpg'
+        ) == 'abc.jpg'
+
+    def test_empty_returns_none(self):
+        assert xtap_core._photo_filename('') is None
+        assert xtap_core._photo_filename(None) is None
+
+    def test_url_with_no_path(self):
+        assert xtap_core._photo_filename('https://pbs.twimg.com/') is None
+
+
+class TestInjectImageLocalPaths:
+    def test_adds_local_path_to_photos(self):
+        tweets = [{
+            'id': '123',
+            'media': [
+                {'type': 'photo', 'url': 'https://pbs.twimg.com/media/abc.jpg:orig'},
+            ],
+        }]
+        pending = xtap_core.inject_image_local_paths(tweets)
+        assert tweets[0]['media'][0]['local_path'] == 'media/123/abc.jpg'
+        assert pending == [{
+            'tweet_id': '123',
+            'url': 'https://pbs.twimg.com/media/abc.jpg:orig',
+            'rel_path': 'media/123/abc.jpg',
+        }]
+
+    def test_skips_video_media(self):
+        tweets = [{
+            'id': '123',
+            'media': [
+                {'type': 'video', 'url': 'https://video.twimg.com/foo.mp4'},
+            ],
+        }]
+        pending = xtap_core.inject_image_local_paths(tweets)
+        assert pending == []
+        assert 'local_path' not in tweets[0]['media'][0]
+
+    def test_skips_tweet_without_id(self):
+        tweets = [{'media': [{'type': 'photo', 'url': 'https://pbs.twimg.com/media/x.jpg'}]}]
+        pending = xtap_core.inject_image_local_paths(tweets)
+        assert pending == []
+
+    def test_handles_missing_media(self):
+        tweets = [{'id': '123'}, {'id': '456', 'media': []}]
+        assert xtap_core.inject_image_local_paths(tweets) == []
+
+    def test_enqueues_article_media(self):
+        tweets = [{
+            'id': '999',
+            'media': [],
+            'is_article': True,
+            'article': {
+                'media': [
+                    {
+                        'url': 'https://pbs.twimg.com/media/HGxr957a0AAzHOk.jpg',
+                        'local_path': 'media/999/HGxr957a0AAzHOk.jpg',
+                    },
+                    {
+                        'url': 'https://pbs.twimg.com/media/HGxr2u5a8AANAOy.jpg',
+                        'local_path': 'media/999/HGxr2u5a8AANAOy.jpg',
+                    },
+                ],
+            },
+        }]
+        pending = xtap_core.inject_image_local_paths(tweets)
+        assert [p['rel_path'] for p in pending] == [
+            'media/999/HGxr957a0AAzHOk.jpg',
+            'media/999/HGxr2u5a8AANAOy.jpg',
+        ]
+
+    def test_skips_article_media_without_local_path(self):
+        tweets = [{
+            'id': '999',
+            'article': {'media': [{'url': 'https://pbs.twimg.com/media/x.jpg'}]},
+        }]
+        assert xtap_core.inject_image_local_paths(tweets) == []
+
+    def test_skips_photo_without_url(self):
+        tweets = [{'id': '123', 'media': [{'type': 'photo', 'url': None}]}]
+        pending = xtap_core.inject_image_local_paths(tweets)
+        assert pending == []
+        assert 'local_path' not in tweets[0]['media'][0]
+
+
+# ---------------------------------------------------------------------------
+# ImageDownloader
+# ---------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    def __init__(self, body):
+        import io
+        self._buf = io.BytesIO(body)
+
+    def read(self, n=-1):
+        return self._buf.read(n)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+def _wait_for_queue(downloader, timeout=5):
+    """Block until the downloader's worker has drained its queue."""
+    deadline = __import__('time').monotonic() + timeout
+    while downloader.queue.unfinished_tasks > 0:
+        if __import__('time').monotonic() > deadline:
+            raise AssertionError('downloader queue did not drain')
+        __import__('time').sleep(0.02)
+
+
+@pytest.fixture
+def downloader(monkeypatch):
+    """A fresh ImageDownloader with no rate-limit delay."""
+    monkeypatch.setenv('XTAP_IMAGE_DELAY_MS', '0')
+    monkeypatch.delenv('XTAP_MAX_MEDIA_MB', raising=False)
+    return xtap_core.ImageDownloader()
+
+
+class TestImageDownloader:
+    def test_successful_download(self, downloader, tmp_path, monkeypatch):
+        body = b'\x89PNG\r\n' + b'x' * 100
+        opens = []
+
+        def fake_urlopen(req, timeout=None):
+            opens.append(req.full_url)
+            return _FakeResponse(body)
+
+        monkeypatch.setattr(xtap_core.urllib.request, 'urlopen', fake_urlopen)
+        downloader.enqueue([{
+            'tweet_id': '1',
+            'url': 'https://pbs.twimg.com/media/abc.jpg:orig',
+            'rel_path': 'media/1/abc.jpg',
+        }], str(tmp_path))
+        _wait_for_queue(downloader)
+        dest = tmp_path / 'media' / '1' / 'abc.jpg'
+        assert dest.read_bytes() == body
+        assert opens == ['https://pbs.twimg.com/media/abc.jpg:orig']
+        # Manifest written
+        entries = [json.loads(l) for l in (tmp_path / 'media-manifest.jsonl').read_text().splitlines()]
+        assert entries[0]['status'] == 'ok'
+        assert entries[0]['bytes'] == len(body)
+        assert entries[0]['tweet_id'] == '1'
+
+    def test_idempotent_skip_existing(self, downloader, tmp_path, monkeypatch):
+        dest_dir = tmp_path / 'media' / '1'
+        dest_dir.mkdir(parents=True)
+        (dest_dir / 'abc.jpg').write_bytes(b'cached-bytes')
+
+        called = []
+        def fake_urlopen(req, timeout=None):
+            called.append(req.full_url)
+            return _FakeResponse(b'should-not-run')
+
+        monkeypatch.setattr(xtap_core.urllib.request, 'urlopen', fake_urlopen)
+        downloader.enqueue([{
+            'tweet_id': '1',
+            'url': 'https://pbs.twimg.com/media/abc.jpg:orig',
+            'rel_path': 'media/1/abc.jpg',
+        }], str(tmp_path))
+        _wait_for_queue(downloader)
+        assert called == []
+        assert (dest_dir / 'abc.jpg').read_bytes() == b'cached-bytes'
+        entries = [json.loads(l) for l in (tmp_path / 'media-manifest.jsonl').read_text().splitlines()]
+        assert entries[0]['status'] == 'exists'
+
+    def test_404_logs_error(self, downloader, tmp_path, monkeypatch):
+        import urllib.error
+        def fake_urlopen(req, timeout=None):
+            raise urllib.error.HTTPError(req.full_url, 404, 'Not Found', {}, None)
+        monkeypatch.setattr(xtap_core.urllib.request, 'urlopen', fake_urlopen)
+        downloader.enqueue([{
+            'tweet_id': '2',
+            'url': 'https://pbs.twimg.com/media/missing.jpg:orig',
+            'rel_path': 'media/2/missing.jpg',
+        }], str(tmp_path))
+        _wait_for_queue(downloader)
+        assert not (tmp_path / 'media' / '2' / 'missing.jpg').exists()
+        entries = [json.loads(l) for l in (tmp_path / 'media-manifest.jsonl').read_text().splitlines()]
+        assert entries[0]['status'] == 'error:http_404'
+
+    def test_quota_skips(self, tmp_path, monkeypatch):
+        # 0 MB quota — every job should be skipped.
+        monkeypatch.setenv('XTAP_IMAGE_DELAY_MS', '0')
+        monkeypatch.setenv('XTAP_MAX_MEDIA_MB', '0')
+        dl = xtap_core.ImageDownloader()
+        called = []
+        monkeypatch.setattr(xtap_core.urllib.request, 'urlopen',
+                            lambda *a, **kw: called.append(1) or _FakeResponse(b''))
+        dl.enqueue([{
+            'tweet_id': '3',
+            'url': 'https://pbs.twimg.com/media/q.jpg',
+            'rel_path': 'media/3/q.jpg',
+        }], str(tmp_path))
+        _wait_for_queue(dl)
+        assert called == []
+        entries = [json.loads(l) for l in (tmp_path / 'media-manifest.jsonl').read_text().splitlines()]
+        assert entries[0]['status'] == 'skipped:quota'
+
+    def test_atomic_partial_cleanup_on_error(self, downloader, tmp_path, monkeypatch):
+        import urllib.error
+        def fake_urlopen(req, timeout=None):
+            raise urllib.error.URLError('connection refused')
+        monkeypatch.setattr(xtap_core.urllib.request, 'urlopen', fake_urlopen)
+        downloader.enqueue([{
+            'tweet_id': '4',
+            'url': 'https://pbs.twimg.com/media/x.jpg',
+            'rel_path': 'media/4/x.jpg',
+        }], str(tmp_path))
+        _wait_for_queue(downloader)
+        # Neither final nor .part should remain.
+        media_dir = tmp_path / 'media' / '4'
+        if media_dir.exists():
+            assert list(media_dir.iterdir()) == []

--- a/tests/test_xtap_daemon.py
+++ b/tests/test_xtap_daemon.py
@@ -231,6 +231,68 @@ class TestAuthorizedRequest:
         assert body['ok'] is True
         conn.close()
 
+    def test_tweets_image_download_flag_enqueues(self, daemon_url, monkeypatch):
+        """When image_download=true, photo media should be enqueued."""
+        import shutil
+        import tempfile
+
+        out_dir = tempfile.mkdtemp(dir=os.path.expanduser('~'), prefix='.xtap-test-')
+        captured = []
+
+        class _Fake:
+            def enqueue(self, jobs, where):
+                captured.append((list(jobs), where))
+
+        monkeypatch.setattr(xtap_daemon, 'get_image_downloader', lambda: _Fake())
+        try:
+            tweet = {
+                'id': '42',
+                'media': [{'type': 'photo', 'url': 'https://pbs.twimg.com/media/HGK.jpg:orig'}],
+            }
+            status, body = _post(
+                daemon_url, '/tweets',
+                body={'outputDir': out_dir, 'tweets': [tweet], 'image_download': True},
+                token=TEST_TOKEN,
+            )
+            assert status == 200
+            assert body['ok'] is True
+            assert body['images_queued'] == 1
+            assert len(captured) == 1
+            jobs, where = captured[0]
+            assert where == os.path.realpath(out_dir)
+            assert jobs[0]['rel_path'] == 'media/42/HGK.jpg'
+        finally:
+            shutil.rmtree(out_dir, ignore_errors=True)
+
+    def test_tweets_no_flag_does_not_enqueue(self, daemon_url, monkeypatch):
+        """Without image_download flag, the downloader is not invoked."""
+        import shutil
+        import tempfile
+
+        out_dir = tempfile.mkdtemp(dir=os.path.expanduser('~'), prefix='.xtap-test-')
+        called = []
+        monkeypatch.setattr(xtap_daemon, 'get_image_downloader', lambda: called.append(1))
+        try:
+            tweet = {
+                'id': '43',
+                'media': [{'type': 'photo', 'url': 'https://pbs.twimg.com/media/HGK.jpg:orig'}],
+            }
+            status, body = _post(
+                daemon_url, '/tweets',
+                body={'outputDir': out_dir, 'tweets': [tweet]},
+                token=TEST_TOKEN,
+            )
+            assert status == 200
+            assert body['images_queued'] == 0
+            assert called == []
+            # local_path was still injected on the tweet (written to JSONL).
+            files = [p for p in os.listdir(out_dir) if p.startswith('tweets-')]
+            assert len(files) == 1
+            line = open(os.path.join(out_dir, files[0])).readline()
+            assert '"local_path": "media/43/HGK.jpg"' in line
+        finally:
+            shutil.rmtree(out_dir, ignore_errors=True)
+
     def test_dump_rejects_dotdot_filename(self, daemon_url):
         """POST /dump with '..' filename should return 400."""
         status, body = _post(

--- a/tests/test_xtap_daemon.py
+++ b/tests/test_xtap_daemon.py
@@ -265,7 +265,9 @@ class TestAuthorizedRequest:
             shutil.rmtree(out_dir, ignore_errors=True)
 
     def test_tweets_no_flag_does_not_enqueue(self, daemon_url, monkeypatch):
-        """Without image_download flag, the downloader is not invoked."""
+        """Without image_download flag, the downloader is not invoked and
+        local_path is NOT injected (keeps JSONL clean for users who don't
+        opt in, and matches the golden-fixture E2E test expectations)."""
         import shutil
         import tempfile
 
@@ -285,11 +287,36 @@ class TestAuthorizedRequest:
             assert status == 200
             assert body['images_queued'] == 0
             assert called == []
-            # local_path was still injected on the tweet (written to JSONL).
             files = [p for p in os.listdir(out_dir) if p.startswith('tweets-')]
             assert len(files) == 1
             line = open(os.path.join(out_dir, files[0])).readline()
-            assert '"local_path": "media/43/HGK.jpg"' in line
+            # local_path NOT present when image_download is off.
+            assert 'local_path' not in line
+        finally:
+            shutil.rmtree(out_dir, ignore_errors=True)
+
+    def test_tweets_string_truthy_does_not_enable(self, daemon_url, monkeypatch):
+        """image_download must be the literal True — string 'false' or 1 must NOT enable."""
+        import shutil
+        import tempfile
+
+        out_dir = tempfile.mkdtemp(dir=os.path.expanduser('~'), prefix='.xtap-test-')
+        called = []
+        monkeypatch.setattr(xtap_daemon, 'get_image_downloader', lambda: called.append(1))
+        try:
+            tweet = {
+                'id': '44',
+                'media': [{'type': 'photo', 'url': 'https://pbs.twimg.com/media/x.jpg'}],
+            }
+            for bad in ['false', 1, 'true', [1]]:
+                status, body = _post(
+                    daemon_url, '/tweets',
+                    body={'outputDir': out_dir, 'tweets': [tweet], 'image_download': bad},
+                    token=TEST_TOKEN,
+                )
+                assert status == 200
+                assert body['images_queued'] == 0, f'truthy {bad!r} should not enable'
+            assert called == []
         finally:
             shutil.rmtree(out_dir, ignore_errors=True)
 


### PR DESCRIPTION
Closes #20.

## Summary
- Daemon: new `ImageDownloader` (single worker, queue, rate-limited, idempotent, atomic write) and `inject_image_local_paths` that walks both top-level photo media and article media.
- `/tweets` reads `image_download` from the request body. Always injects `local_path` into JSONL; only enqueues images when the flag is on. Response now includes `images_queued`.
- Manifest: append-only `media-manifest.jsonl` with `{timestamp, tweet_id, url, local_path, status, bytes}`. Statuses: `ok`, `exists`, `skipped:quota`, `error:http_404`, `error:URLError`, etc. 429 → exponential backoff.
- Extension: `imageDownload` flag in `chrome.storage.local` (default false), sent as `image_download` in `/tweets`. Popup gets a "Download images automatically" checkbox.
- Env knobs: `XTAP_IMAGE_DELAY_MS` (default 100), `XTAP_MAX_MEDIA_MB` (default unlimited).
- Bumps to v0.23.0 across `manifest.json`, `manifest.firefox.json`, and daemon `VERSION`.

## Feasibility
Confirmed `pbs.twimg.com/.../<file>.jpg:orig` returns 200 publicly with no cookies/auth — see issue's open question.

## Test plan
- [x] 96 Python tests pass (10 new for `_photo_filename`, `inject_image_local_paths` regular + article, `ImageDownloader` success / idempotent / 404 / quota / partial cleanup, plus 2 daemon flow tests).
- [x] 86 JS tests still green.
- [x] Live end-to-end on macOS: 3 timeline photos + 14 article images (`U.S. Tech Coverage Update`) downloaded into `media/<tweet_id>/`, all logged `ok` in manifest.
- [ ] Linux / Windows smoke test (no behavioral changes vs existing daemon paths, but worth a sanity check).

## Out of scope
Per the issue: video pipeline changes, UI gallery, ZIP bundling.