### PR TITLE
fix: backfill images when auto-download is enabled after capture

### DIFF
--- a/background.js
+++ b/background.js
@@ -13,6 +13,12 @@ let captureEnabled = true;
 let buffer = [];
 let flushTimer = null;
 let seenIds = new Set();
+// Session-only set of tweet IDs already forwarded for image-backfill this SW
+// lifetime. Lets us re-enter the daemon once per duplicate-with-photos so
+// images skipped at original capture time get downloaded, without spamming
+// the daemon on every scroll/re-navigation. Cleared on SW restart by design
+// — the downloader's per-file os.path.exists is the source of truth.
+let imageCheckedIds = new Set();
 let sessionCount = 0;
 let allTimeCount = 0;
 let outputDir = '';
@@ -484,7 +490,7 @@ function enqueueTweets(tweets, endpoint = 'unknown') {
       }
     }
 
-    if (!dedupTweet(tweet, seenIds)) {
+    if (!dedupTweet(tweet, seenIds, { imageBackfill: imageDownload, imageCheckedIds })) {
       emitTraceEvent({ timestamp: Date.now(), endpoint, tweetId: tweet.id, status: 'DEDUPLICATED', reason: 'seenIds' });
       continue;
     }
@@ -497,6 +503,10 @@ function enqueueTweets(tweets, endpoint = 'unknown') {
   if (seenIds.size > MAX_SEEN_IDS) {
     const arr = [...seenIds];
     seenIds = new Set(arr.slice(arr.length - MAX_SEEN_IDS));
+  }
+  if (imageCheckedIds.size > MAX_SEEN_IDS) {
+    const arr = [...imageCheckedIds];
+    imageCheckedIds = new Set(arr.slice(arr.length - MAX_SEEN_IDS));
   }
 
   const dupeCount = tweets.length - newCount;

--- a/lib/dedup.js
+++ b/lib/dedup.js
@@ -12,11 +12,40 @@
  *
  * - Tweets without an id are always new (and not tracked).
  * - Article tweets bypass dedup — they enrich a previously captured stub.
+ * - When `options.imageBackfill` is set and the tweet has photo media,
+ *   a duplicate is also let through once per session (tracked in
+ *   `options.imageCheckedIds`) so the daemon can download images that
+ *   were skipped when image-download was off at original capture time.
+ *   The downloader's per-file `os.path.exists` check makes repeats cheap.
  */
-export function dedupTweet(tweet, seenIds) {
-  if (tweet.id && seenIds.has(tweet.id) && !tweet.is_article) {
+export function dedupTweet(tweet, seenIds, options = {}) {
+  const { imageBackfill = false, imageCheckedIds = null } = options;
+
+  const isDup = !!(tweet.id && seenIds.has(tweet.id));
+  const isArticle = !!tweet.is_article;
+  const wantsImageBackfill = (
+    imageBackfill &&
+    !!tweet.id &&
+    imageCheckedIds &&
+    !imageCheckedIds.has(tweet.id) &&
+    hasPhotoMedia(tweet)
+  );
+
+  if (isDup && !isArticle && !wantsImageBackfill) {
     return false;
   }
+
   if (tweet.id) seenIds.add(tweet.id);
+  if (wantsImageBackfill) imageCheckedIds.add(tweet.id);
+
   return true;
+}
+
+function hasPhotoMedia(tweet) {
+  const media = tweet.media;
+  if (!Array.isArray(media)) return false;
+  for (const m of media) {
+    if (m && m.type === 'photo') return true;
+  }
+  return false;
 }

--- a/tests/dedup-xhr.test.mjs
+++ b/tests/dedup-xhr.test.mjs
@@ -65,6 +65,77 @@ describe('dedupTweet (Bug 1: undefined poisoning)', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Image backfill bypass: re-emit duplicates with photos so newly-enabled
+// auto-image-download can fetch media for already-scraped tweets. Once per
+// session per tweet ID, gated by imageCheckedIds.
+// ---------------------------------------------------------------------------
+
+const photoTweet = (id) => ({
+  id,
+  text: 'pic',
+  media: [{ type: 'photo', url: 'https://pbs.twimg.com/media/x.jpg:orig' }],
+});
+
+describe('dedupTweet (image-backfill bypass)', () => {
+  it('lets a duplicate photo tweet through once when imageBackfill is on', () => {
+    const seenIds = new Set(['1']);
+    const imageCheckedIds = new Set();
+    const opts = { imageBackfill: true, imageCheckedIds };
+    assert.equal(dedupTweet(photoTweet('1'), seenIds, opts), true,
+      'first duplicate with photos should pass through for backfill');
+    assert.ok(imageCheckedIds.has('1'),
+      'tweet must be marked as image-checked so we do not re-forward');
+  });
+
+  it('blocks the same duplicate photo tweet on the second pass', () => {
+    const seenIds = new Set(['1']);
+    const imageCheckedIds = new Set();
+    const opts = { imageBackfill: true, imageCheckedIds };
+    assert.equal(dedupTweet(photoTweet('1'), seenIds, opts), true);
+    assert.equal(dedupTweet(photoTweet('1'), seenIds, opts), false,
+      'second pass should be deduplicated again');
+  });
+
+  it('does not bypass dedup for duplicates without photo media', () => {
+    const seenIds = new Set(['1']);
+    const imageCheckedIds = new Set();
+    const opts = { imageBackfill: true, imageCheckedIds };
+    assert.equal(dedupTweet({ id: '1', text: 'no media' }, seenIds, opts), false);
+    assert.equal(
+      dedupTweet({ id: '1', text: 'video', media: [{ type: 'video' }] }, seenIds, opts),
+      false,
+      'video-only tweets are not handled by the image pipeline'
+    );
+    assert.ok(!imageCheckedIds.has('1'));
+  });
+
+  it('does not bypass when imageBackfill is off (default)', () => {
+    const seenIds = new Set(['1']);
+    assert.equal(dedupTweet(photoTweet('1'), seenIds), false);
+    assert.equal(
+      dedupTweet(photoTweet('1'), seenIds, { imageBackfill: false, imageCheckedIds: new Set() }),
+      false
+    );
+  });
+
+  it('marks first-seen photo tweets in imageCheckedIds', () => {
+    const seenIds = new Set();
+    const imageCheckedIds = new Set();
+    const opts = { imageBackfill: true, imageCheckedIds };
+    assert.equal(dedupTweet(photoTweet('42'), seenIds, opts), true);
+    assert.ok(seenIds.has('42'));
+    assert.ok(imageCheckedIds.has('42'),
+      'first-seen photo tweets must also be tracked so the next view does not re-forward');
+  });
+
+  it('does not require imageCheckedIds when imageBackfill is off', () => {
+    const seenIds = new Set();
+    assert.equal(dedupTweet({ id: '1', text: 'first' }, seenIds), true);
+    assert.equal(dedupTweet({ id: '1', text: 'dupe' }, seenIds), false);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Bug 2: XHR listener stacking — evaluates production content-main.js via vm
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #36.

## Summary
- Re-enabling **Download images automatically** now triggers media download for tweets already in `seenIds`. Previously the SW dedup gate dropped them before `collect_image_jobs` could run on the daemon.
- `dedupTweet` accepts an optional `{ imageBackfill, imageCheckedIds }`. A duplicate with photo media is allowed through once per SW session and tracked in `imageCheckedIds`; second view this session is deduplicated again. Backwards-compatible with existing 2-arg callers.
- Daemon untouched: `write_tweets` still dedups JSONL appends and the downloader's per-file `os.path.exists` check at `xtap_core.py:585` skips files already on disk. Filesystem remains the source of truth, so the fix self-heals across deletions and interrupted downloads.

## Why this design
- Filesystem is already the per-file source of truth — no schema change, no persistent manifest, no migration.
- Session-only `imageCheckedIds` (cleared on SW restart) bounds re-forwards to once per session per tweet, avoiding image-log spam on every scroll while keeping memory bounded (capped at `MAX_SEEN_IDS`).
- Mirrors the existing `is_article` bypass pattern in `lib/dedup.js`.

## Test plan
- [x] `node --test tests/*.test.mjs` — 92 pass (6 new cases for backfill on/off, photo vs no-photo vs video-only, once-per-session, first-seen tracking).
- [x] `python3 -m pytest tests/` — 135 pass.
- [x] Manual: toggle setting off, view a tweet with photos, confirm no `media/<id>/`. Toggle on, re-navigate, confirm files appear.
- [x] Manual: scroll a heavy timeline twice — confirm no per-scroll daemon spam (each tweet forwarded at most once for backfill per SW session).