### PR TITLE
chore: bump version to 0.23.1

### DIFF
--- a/manifest.firefox.json
+++ b/manifest.firefox.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "xTap",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "description": "Passively captures tweets from X/Twitter as you browse",
   "permissions": [
     "storage",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "xTap",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "description": "Passively captures tweets from X/Twitter as you browse",
   "permissions": ["storage", "nativeMessaging"],
   "host_permissions": ["*://*.x.com/*", "*://*.twitter.com/*", "http://127.0.0.1/*"],

--- a/native-host/xtap_daemon.py
+++ b/native-host/xtap_daemon.py
@@ -18,7 +18,7 @@ from xtap_core import (DEFAULT_OUTPUT_DIR, load_seen_ids, resolve_output_dir,
                        check_ytdlp, start_download, get_download_status,
                        collect_image_jobs, get_image_downloader)
 
-VERSION = '0.23.0'
+VERSION = '0.23.1'
 BIND_HOST = '127.0.0.1'
 BIND_PORT = int(os.environ.get('XTAP_DAEMON_PORT', 17381))
 MAX_BODY_SIZE = 10 * 1024 * 1024  # 10 MB


### PR DESCRIPTION
Patch release.

## What's in 0.23.1
- #37 — Backfill images for already-scraped tweets when "Download images automatically" is toggled on after capture (closes #36).

## Files updated
- `manifest.json`: 0.23.0 → 0.23.1
- `manifest.firefox.json`: regenerated via `node scripts/build-firefox-manifest.js`
- `native-host/xtap_daemon.py` (`VERSION`): 0.23.0 → 0.23.1

## Test plan
- [x] `node --test tests/*.test.mjs` — 92 pass
- [x] `python3 -m pytest tests/` — 135 pass