### PR TITLE
[codex] bump version to 0.23.2

### DIFF
--- a/manifest.firefox.json
+++ b/manifest.firefox.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "xTap",
-  "version": "0.23.1",
+  "version": "0.23.2",
   "description": "Passively captures tweets from X/Twitter as you browse",
   "permissions": [
     "storage",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "xTap",
-  "version": "0.23.1",
+  "version": "0.23.2",
   "description": "Passively captures tweets from X/Twitter as you browse",
   "permissions": ["storage", "nativeMessaging"],
   "host_permissions": ["*://*.x.com/*", "*://*.twitter.com/*", "http://127.0.0.1/*"],

--- a/native-host/xtap_daemon.py
+++ b/native-host/xtap_daemon.py
@@ -18,7 +18,7 @@ from xtap_core import (DEFAULT_OUTPUT_DIR, load_seen_ids, resolve_output_dir,
                        check_ytdlp, start_download, get_download_status,
                        collect_image_jobs, get_image_downloader)
 
-VERSION = '0.23.1'
+VERSION = '0.23.2'
 BIND_HOST = '127.0.0.1'
 BIND_PORT = int(os.environ.get('XTAP_DAEMON_PORT', 17381))
 MAX_BODY_SIZE = 10 * 1024 * 1024  # 10 MB


### PR DESCRIPTION
## Summary

Bump xTap from 0.23.1 to 0.23.2 after #46.

Changes:
- Update `manifest.json` to 0.23.2.
- Regenerate `manifest.firefox.json` from the Chrome manifest.
- Update `native-host/xtap_daemon.py` `VERSION` to 0.23.2.

## Validation

- `python3 -m pytest tests/ -v && node --test tests/*.test.mjs`